### PR TITLE
Release v0.6.0 - Chart.version v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.6.0 (February 16, 2024)
+
+ENHANCEMENTS:
+
+* chart: Rename env variables in sk8l-ui-configmap to work with vite [[GH-8](https://github.com/danroux/sk8l-api/issues/8)]
+
+IMPROVEMENTS:
+
+* Mark cronjobs/jobs/pods as failed when containers errored at init because of configuration errors. [[GH-7](https://github.com/danroux/sk8l-api/issues/7)]
+
 ## v0.5.0 (February 01, 2024)
 
 SECURITY:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help: ## This help.
 
 # Bump these on release
 VERSION_MAJOR ?= 0
-VERSION_MINOR ?= 5
+VERSION_MINOR ?= 6
 VERSION_PATCH ?= 0
 
 VERSION ?= v$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)

--- a/charts/sk8l/Chart.yaml
+++ b/charts/sk8l/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sk8l
-version: 0.6.0
-appVersion: "0.5.0"
+version: 0.7.0
+appVersion: "0.6.0"
 description: |
   sk8l collects Cronjob activity, displays it visually in the UI and publishes cronjob metrics
 keywords:

--- a/charts/sk8l/templates/deployment.yaml
+++ b/charts/sk8l/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: sk8l-api
           {{- template "securityContext.container" . }}
           {{- $apiImage := .Values.sk8lApi.image | default "danroux/sk8l-api" }}
-          {{- $apiTag := .Values.sk8lApi.imageTag | default "v0.5.0" }}
+          {{- $apiTag := .Values.sk8lApi.imageTag | default "v0.6.0" }}
           image: {{ printf "%s:%s" $apiImage $apiTag }}
           imagePullPolicy: {{ .Values.sk8lApi.imagePullPolicy | default "IfNotPresent" | quote }}
           ports:

--- a/charts/sk8l/templates/ui-deployment.yaml
+++ b/charts/sk8l/templates/ui-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             seccompProfile:
               type: RuntimeDefault
           {{- $uiImage := .Values.sk8lUi.image | default "danroux/sk8l-ui" }}
-          {{- $uiTag := .Values.sk8lUi.imageTag | default "v0.5.0" }}
+          {{- $uiTag := .Values.sk8lUi.imageTag | default "v0.6.0" }}
           image: {{ printf "%s:%s" $uiImage $uiTag }}
           imagePullPolicy: {{ .Values.sk8lUi.imagePullPolicy | default "IfNotPresent" | quote }}
           command:
@@ -85,7 +85,7 @@ spec:
         - name: sk8l-ui
           {{- template "securityContext.container" . }}
           {{- $uiImage := .Values.sk8lUi.image | default "danroux/sk8l-ui" }}
-          {{- $uiTag := .Values.sk8lUi.imageTag | default "v0.5.0" }}
+          {{- $uiTag := .Values.sk8lUi.imageTag | default "v0.6.0" }}
           image: {{ printf "%s:%s" $uiImage $uiTag }}
           imagePullPolicy: {{ .Values.sk8lUi.imagePullPolicy | default "IfNotPresent" | quote }}
           ports:

--- a/charts/sk8l/values.yaml
+++ b/charts/sk8l/values.yaml
@@ -22,7 +22,7 @@ serviceAccount:
     annotations: {}
 sk8lApi:
   image: "danroux/sk8l-api"
-  imageTag: "v0.5.0"
+  imageTag: "v0.6.0"
   imagePullPolicy: ""
   autoscaling:
     enabled: true
@@ -52,7 +52,7 @@ sk8lApi:
   #             path: ca-key.pem
 sk8lUi:
   image: "danroux/sk8l-ui"
-  imageTag: "v0.5.0"
+  imageTag: "v0.6.0"
   imagePullPolicy: ""
   volumeMounts:
     - name: nginx-cache


### PR DESCRIPTION
## v0.6.0 

* chart appVersion: 0.6.0
* chart version: 0.7.0

ENHANCEMENTS:

* chart: Rename env variables in sk8l-ui-configmap to work with vite [[GH-8](https://github.com/danroux/sk8l-api/issues/8)]

IMPROVEMENTS:

* Mark cronjobs/jobs/pods as failed when containers errored at init because of configuration errors. [[GH-7](https://github.com/danroux/sk8l-api/issues/7)]