### PR TITLE
Release v0.9.0 - Chart.version v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## v0.9.0 (March 19, 2024)
+
+SECURITY:
+
+* Upgrade `google.golang.org/protobuf` => `v1.33.0` to remove [CWE-835](https://cwe.mitre.org/data/definitions/835.html) / [CVE-2024-24786](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-24786) vulnerability. [[GH-14](https://github.com/danroux/sk8l-api/issues/14)]
+
+IMPROVEMENTS:
+
+* Reduce calls to the k8s api by improving how cronjobs are collected [[GH-14](https://github.com/danroux/sk8l-api/issues/14)]
+
+DEPENDENCIES:
+
+* - Update `k8s.io/apimachinery` submodule => `v0.27.12` [[GH-14](https://github.com/danroux/sk8l-api/issues/14)]
+* - Update go dependencies:
+  - `google.golang.org/protobuf` => `v1.33.0`
+  - `k8s.io/api` => `v0.27.12`
+  - `k8s.io/apimachinery` => `v0.27.12`
+  - `k8s.io/client-go` => `v0.27.12`
+* - Remove `github.com/golang/protobuf` [[GH-14](https://github.com/danroux/sk8l-api/issues/14)]
+
 ## v0.8.0 (February 29, 2024)
 
 ENHANCEMENTS:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help: ## This help.
 
 # Bump these on release
 VERSION_MAJOR ?= 0
-VERSION_MINOR ?= 8
+VERSION_MINOR ?= 9
 VERSION_PATCH ?= 0
 
 VERSION ?= v$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)

--- a/charts/sk8l/Chart.yaml
+++ b/charts/sk8l/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: sk8l
-version: 0.9.0
-appVersion: "0.8.0"
+version: 0.10.0
+appVersion: "0.9.0"
 description: |
-  sk8l collects Cronjob activity, displays it visually in the UI and publishes cronjob metrics
+  sk8l collects Cronjob activity, displays it visually in the UI and publishes cronjob metrics to prometheus
 keywords:
   - Cronjob
   - Monitoring

--- a/charts/sk8l/templates/deployment.yaml
+++ b/charts/sk8l/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: sk8l-api
           {{- template "securityContext.container" . }}
           {{- $apiImage := .Values.sk8lApi.image | default "danroux/sk8l-api" }}
-          {{- $apiTag := .Values.sk8lApi.imageTag | default "v0.8.0" }}
+          {{- $apiTag := .Values.sk8lApi.imageTag | default "v0.9.0" }}
           image: {{ printf "%s:%s" $apiImage $apiTag }}
           imagePullPolicy: {{ .Values.sk8lApi.imagePullPolicy | default "IfNotPresent" | quote }}
           ports:

--- a/charts/sk8l/templates/ui-deployment.yaml
+++ b/charts/sk8l/templates/ui-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             seccompProfile:
               type: RuntimeDefault
           {{- $uiImage := .Values.sk8lUi.image | default "danroux/sk8l-ui" }}
-          {{- $uiTag := .Values.sk8lUi.imageTag | default "v0.8.0" }}
+          {{- $uiTag := .Values.sk8lUi.imageTag | default "v0.9.0" }}
           image: {{ printf "%s:%s" $uiImage $uiTag }}
           imagePullPolicy: {{ .Values.sk8lUi.imagePullPolicy | default "IfNotPresent" | quote }}
           command:
@@ -85,7 +85,7 @@ spec:
         - name: sk8l-ui
           {{- template "securityContext.container" . }}
           {{- $uiImage := .Values.sk8lUi.image | default "danroux/sk8l-ui" }}
-          {{- $uiTag := .Values.sk8lUi.imageTag | default "v0.8.0" }}
+          {{- $uiTag := .Values.sk8lUi.imageTag | default "v0.9.0" }}
           image: {{ printf "%s:%s" $uiImage $uiTag }}
           imagePullPolicy: {{ .Values.sk8lUi.imagePullPolicy | default "IfNotPresent" | quote }}
           ports:

--- a/charts/sk8l/values.yaml
+++ b/charts/sk8l/values.yaml
@@ -22,7 +22,7 @@ serviceAccount:
     annotations: {}
 sk8lApi:
   image: "danroux/sk8l-api"
-  imageTag: "v0.8.0"
+  imageTag: "v0.9.0"
   imagePullPolicy: ""
   autoscaling:
     enabled: true
@@ -52,7 +52,7 @@ sk8lApi:
   #             path: ca-key.pem
 sk8lUi:
   image: "danroux/sk8l-ui"
-  imageTag: "v0.8.0"
+  imageTag: "v0.9.0"
   imagePullPolicy: ""
   volumeMounts:
     - name: nginx-cache


### PR DESCRIPTION
SECURITY:

* Upgrade `google.golang.org/protobuf` => `v1.33.0` to remove [CWE-835](https://cwe.mitre.org/data/definitions/835.html) / [CVE-2024-24786](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-24786) vulnerability. [[GH-14](https://github.com/danroux/sk8l-api/issues/14)]

IMPROVEMENTS:

* Reduce calls to the k8s api by improving how cronjobs are collected [[GH-14](https://github.com/danroux/sk8l-api/issues/14)]

DEPENDENCIES:

- Update `k8s.io/apimachinery` submodule => `v0.27.12` [[GH-14](https://github.com/danroux/sk8l-api/issues/14)]
- Update go dependencies:
  - `google.golang.org/protobuf` => `v1.33.0`
  - `k8s.io/api` => `v0.27.12`
  - `k8s.io/apimachinery` => `v0.27.12`
  - `k8s.io/client-go` => `v0.27.12`
- Remove `github.com/golang/protobuf` [[GH-14](https://github.com/danroux/sk8l-api/issues/14)]