### PR TITLE
Remove a duplicate runAsNonRoot from the UI Deployment

### DIFF
--- a/charts/sk8l/templates/ui-deployment.yaml
+++ b/charts/sk8l/templates/ui-deployment.yaml
@@ -29,7 +29,6 @@ spec:
       automountServiceAccountToken: false
       serviceAccountName: {{ .Values.serviceAccount.metadata.name | default "sk8l" }}
       {{- template "securityContext.pod" . }}
-        runAsNonRoot: true
         runAsGroup: {{ .Values.envoyGid | default 101 }}
         runAsUser: {{ .Values.envoyUid | default 101 }}
       initContainers:


### PR DESCRIPTION
It looks like we don't need this one in the ui-deployment template, since it's in the default values here: 
https://github.com/polarislabs/sk8l-api/blob/9026d11336cb658bea35a6d020012b181de547ac/charts/sk8l/values.yaml#L130

Closes #16 