### PR TITLE
Release v0.10.0 - Chart.version v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## v0.10.0 (April 12, 2024)
+
+IMPROVEMENTS:
+
+* ci/k8s: Build and test againts matching apimachinery protos during testing on CI [[GH-33](https://github.com/danroux/sk8l-api/issues/33)]
+* go: Improved go and envoy tls{MinVersion, MaxVersion} [[GH-33](https://github.com/danroux/sk8l-api/issues/33)]
+
+BUG FIXES:
+
+* Chart: [Remove a duplicate runAsNonRoot from the UI Deployment #17](https://github.com/danroux/sk8l-api/pull/17) by dbirks [[GH-18](https://github.com/danroux/sk8l-api/issues/18)]
+* go: Fixed a bug on DashboardAnnotations when annotations.tmpl was missing [[GH-33](https://github.com/danroux/sk8l-api/issues/33)]
+
+DEPENDENCIES:
+
+* ci/dependabot: Configure dependabot version updates [[GH-20](https://github.com/danroux/sk8l-api/issues/20)]
+* ci/dependabot: docker deps:(deps): bump alpine from 3.18.3 to 3.19.1 [[GH-22](https://github.com/danroux/sk8l-api/issues/22)]
+* ci/dependabot: docker deps:(deps): bump golang from 1.22.0 to 1.22.2 [[GH-21](https://github.com/danroux/sk8l-api/issues/21)]
+* ci/dependabot: gha deps:(deps): bump actions/checkout from 4.1.1 to 4.1.2 [[GH-30](https://github.com/danroux/sk8l-api/issues/30)]
+* ci/dependabot: go deps:(deps): bump github.com/prometheus/client_golang from 1.17.0 to 1.19.0 [[GH-26](https://github.com/danroux/sk8l-api/issues/26)]
+* gha/dependabot: Create .changelog entry on dependabot PRs [[GH-27](https://github.com/danroux/sk8l-api/issues/27)]
+* gha/k8s: Build && push Docker dev image for testing on CI [[GH-29](https://github.com/danroux/sk8l-api/issues/29)]
+* gha/k8s: Setup K8s pipeline in GHA [[GH-28](https://github.com/danroux/sk8l-api/issues/28)]
+* golang: Setup checks related to golang in gha/ci [[GH-19](https://github.com/danroux/sk8l-api/issues/19)]
+* deps/go: Update go dependencies: grpc 1.59.0 => 1.63.2 && client-go, apimachinery 0.27.12 => 0.29.3 [[GH-32](https://github.com/danroux/sk8l-api/issues/32)]
+
 ## v0.9.0 (March 19, 2024)
 
 SECURITY:

--- a/charts/sk8l/Chart.yaml
+++ b/charts/sk8l/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sk8l
-version: 0.10.1
-appVersion: 0.9.0
+version: 0.11.0
+appVersion: 0.10.0
 description: |
   sk8l collects Cronjob activity, displays it visually in the UI and publishes cronjob metrics to prometheus
 keywords:

--- a/charts/sk8l/templates/deployment.yaml
+++ b/charts/sk8l/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: sk8l-api
           {{- template "securityContext.container" . }}
           {{- $apiImage := .Values.sk8lApi.image | default "danroux/sk8l-api" }}
-          {{- $apiTag := .Values.sk8lApi.imageTag | default "v0.9.0" }}
+          {{- $apiTag := .Values.sk8lApi.imageTag | default "v0.10.0" }}
           image: {{ printf "%s:%s" $apiImage $apiTag }}
           imagePullPolicy: {{ .Values.sk8lApi.imagePullPolicy | default "IfNotPresent" | quote }}
           ports:

--- a/charts/sk8l/values.yaml
+++ b/charts/sk8l/values.yaml
@@ -22,7 +22,7 @@ serviceAccount:
     annotations: {}
 sk8lApi:
   image: "danroux/sk8l-api"
-  imageTag: "v0.9.0"
+  imageTag: "v0.10.0"
   imagePullPolicy: ""
   autoscaling:
     enabled: true
@@ -37,19 +37,25 @@ sk8lApi:
   #   projected:
   #     sources:
   #     - secret:
-  #         name: tls-server-cert
+  #         name: sk8l-tls-server-cert
   #         items:
   #           - key: tls.crt
   #             path: server-cert.pem
   #           - key: tls.key
   #             path: server-key.pem
-  #     - secret:
-  #         name: tls-ca-cert
-  #         items:
-  #           - key: tls.crt
+  #           - key: ca.crt
   #             path: ca-cert.pem
-  #           - key: tls.key
-  #             path: ca-key.pem
+  # - name: ca-certificate-only
+  #   projected:
+  #     sources:
+  #     - configMap:
+  #         name: sk8l
+  #         # defaultMode: 0644
+  #         # optional: false
+  #         items:
+  #           - key: trust-bundle.crt
+  #             path: ca-certificates.crt
+
 sk8lUi:
   image: "danroux/sk8l-ui"
   imageTag: "v0.9.0"
@@ -81,20 +87,24 @@ sk8lUi:
   #   projected:
   #     sources:
   #     - secret:
-  #         name: tls-server-cert
+  #         name: sk8l-tls-server-cert
   #         items:
   #           - key: tls.crt
   #             path: server-cert.pem
   #           - key: tls.key
   #             path: server-key.pem
-  #     - secret:
-  #         name: tls-ca-cert
-  #         items:
-  #           - key: tls.crt
+  #           - key: ca.crt
   #             path: ca-cert.pem
-  #           - key: tls.key
-  #             path: ca-key.pem
-
+  # - name: ca-certificate-only
+  #   projected:
+  #     sources:
+  #     - configMap:
+  #         name: sk8l
+  #         # defaultMode: 0644
+  #         # optional: false
+  #         items:
+  #           - key: trust-bundle.crt
+  #             path: ca-certificates.crt
 envoy:
   image: ""
   volumeMounts:
@@ -104,6 +114,7 @@ envoy:
   # You can mount a volume with a secret with the keys:
   # - tls.crt.
   # - tls.key.
+  # - ca.crt.
   #
   # Eg.:
   # - name: tls-certs


### PR DESCRIPTION
IMPROVEMENTS:

* ci/k8s: Build and test againts matching apimachinery protos during testing on CI [[GH-33](https://github.com/danroux/sk8l-api/issues/33)]
* go: Improved go and envoy tls{MinVersion, MaxVersion} [[GH-33](https://github.com/danroux/sk8l-api/issues/33)]

BUG FIXES:

* Chart: [Remove a duplicate runAsNonRoot from the UI Deployment #17](https://github.com/danroux/sk8l-api/pull/17) by dbirks [[GH-18](https://github.com/danroux/sk8l-api/issues/18)]
* go: Fixed a bug on DashboardAnnotations when annotations.tmpl was missing [[GH-33](https://github.com/danroux/sk8l-api/issues/33)]

DEPENDENCIES:

* ci/dependabot: Configure dependabot version updates [[GH-20](https://github.com/danroux/sk8l-api/issues/20)]
* ci/dependabot: docker deps:(deps): bump alpine from 3.18.3 to 3.19.1 [[GH-22](https://github.com/danroux/sk8l-api/issues/22)]
* ci/dependabot: docker deps:(deps): bump golang from 1.22.0 to 1.22.2 [[GH-21](https://github.com/danroux/sk8l-api/issues/21)]
* ci/dependabot: gha deps:(deps): bump actions/checkout from 4.1.1 to 4.1.2 [[GH-30](https://github.com/danroux/sk8l-api/issues/30)]
* ci/dependabot: go deps:(deps): bump github.com/prometheus/client_golang from 1.17.0 to 1.19.0 [[GH-26](https://github.com/danroux/sk8l-api/issues/26)]
* gha/dependabot: Create .changelog entry on dependabot PRs [[GH-27](https://github.com/danroux/sk8l-api/issues/27)]
* gha/k8s: Build && push Docker dev image for testing on CI [[GH-29](https://github.com/danroux/sk8l-api/issues/29)]
* gha/k8s: Setup K8s pipeline in GHA [[GH-28](https://github.com/danroux/sk8l-api/issues/28)]
* golang: Setup checks related to golang in gha/ci [[GH-19](https://github.com/danroux/sk8l-api/issues/19)]
* deps/go: Update go dependencies: grpc 1.59.0 => 1.63.2 && client-go, apimachinery 0.27.12 => 0.29.3 [[GH-32](https://github.com/danroux/sk8l-api/issues/32)]