### PR TITLE
Update grpc-go, k8s.io/apimachinery

### DIFF
--- a/.changelog/72.txt
+++ b/.changelog/72.txt
@@ -1,0 +1,22 @@
+```release-note:enhancement
+ci/dependabot: go:(deps): bump google.golang.org/grpc from 1.63.2 to 1.64.0
+
+go:(deps): bump google.golang.org/grpc from 1.63.2 to 1.64.0
+
+Bumps [google.golang.org/grpc](https://github.com/grpc/grpc-go) from 1.63.2 to 1.64.0.
+- [Release notes](https://github.com/grpc/grpc-go/releases)
+- [Commits](https://github.com/grpc/grpc-go/compare/v1.63.2...v1.64.0)
+
+---
+updated-dependencies:
+- dependency-name: google.golang.org/grpc
+  dependency-type: direct:production
+  update-type: version-update:semver-minor
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+```
+
+```release-note:dependency
+- Update `k8s.io/apimachinery` submodule => `v0.30.1`
+```

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/dgraph-io/badger/v4 v4.2.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/prometheus/client_golang v1.19.1
-	google.golang.org/grpc v1.63.2
+	google.golang.org/grpc v1.64.0
 	google.golang.org/protobuf v1.34.1
 	k8s.io/api v0.30.1
 	k8s.io/apimachinery v0.30.1

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20240401170217-c3f982113cda h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240401170217-c3f982113cda/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
-google.golang.org/grpc v1.63.2 h1:MUeiw1B2maTVZthpU5xvASfTh3LDbxHd6IJ6QQVU+xM=
-google.golang.org/grpc v1.63.2/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDomNkRA=
+google.golang.org/grpc v1.64.0 h1:KH3VH9y/MgNQg1dE7b3XfVK0GsPSIzJwdF617gUSbvY=
+google.golang.org/grpc v1.64.0/go.mod h1:oxjF8E3FBnjp+/gVFYdWacaLDx9na1aqy9oovLpxQYg=
 google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=
 google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/metrics.go
+++ b/metrics.go
@@ -65,13 +65,13 @@ var (
 )
 
 func recordMetrics(ctx context.Context, svr *Sk8lServer) {
-	conn, err := grpc.Dial(svr.Target, svr.Options...)
+	conn, err := grpc.NewClient(svr.Target, svr.Options...)
+	if err != nil {
+		panic(fmt.Sprintf("grpc.NewClient(%s) failed: %v", svr.Target, err))
+	}
+
 	c := protos.NewCronjobClient(conn)
 	subSystem := svr.K8sClient.namespace
-
-	if err != nil {
-		panic(err)
-	}
 
 	log.Println("Metrics: Starting metrics collection")
 	req := &protos.CronjobsRequest{}


### PR DESCRIPTION
- Update `grpc-go` `v1.63.2` => `v1.64.0`
- Update `k8s.io/apimachinery` submodule `0.29.2` => `v0.30.1`