### PR TITLE
Increase golangci-lint version to fix golangci-lint jobs

### DIFF
--- a/.changelog/175.txt
+++ b/.changelog/175.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ci: Fix golangci-lint configuration, increase golangci version to 1.64.8. Rename deprecated linters and address issues raised now that the linters work again.
+```

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -37,7 +37,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
         with:
-          version: v1.57
+          version: v1.62
           # Optional: golangci-lint command line arguments.
           #
           # Note: By default, the `.golangci.yml` file should be at the root of the repository.

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -35,9 +35,10 @@ jobs:
           cache: false
         id: go
       - name: golangci-lint
+        # v7.0.0 supports golangci-lint v2 only.
         uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
         with:
-          version: v1.62
+          version: v1.64.8
           # Optional: golangci-lint command line arguments.
           #
           # Note: By default, the `.golangci.yml` file should be at the root of the repository.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -178,9 +178,9 @@ linters-settings:
     # Available rules: https://github.com/securego/gosec#available-rules
     # Default: [] - means include all rules
     includes: []
-    # https://github.com/moby/moby/issues/48358
-    # https://github.com/influxdata/telegraf/issues/15798
     excludes:
+      # https://github.com/moby/moby/issues/48358
+      # https://github.com/influxdata/telegraf/issues/15798
       - G115 # Potential integer overflow when converting between integer types
 
   govet:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -178,6 +178,10 @@ linters-settings:
     # Available rules: https://github.com/securego/gosec#available-rules
     # Default: [] - means include all rules
     includes: []
+    # https://github.com/moby/moby/issues/48358
+    # https://github.com/influxdata/telegraf/issues/15798
+    excludes:
+      - G115 # Potential integer overflow when converting between integer types
 
   govet:
     enable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,10 +44,10 @@ linters:
     - gocyclo
     - godot
     - godox
-    - goerr113
+    - err113
     - gofmt
     - goimports
-    - gomnd
+    - mnd
     - goprintffuncname
     - gosec
     - gosimple
@@ -59,7 +59,7 @@ linters:
     - nolintlint
     - revive
     - rowserrcheck
-    - exportloopref
+    - copyloopvar
     - staticcheck
     - stylecheck
     - typecheck
@@ -150,7 +150,7 @@ linters-settings:
     # Default false
     ignore-comments: true
 
-  gomnd:
+  mnd:
     # List of enabled checks, see https://github.com/tommy-muehle/go-mnd/#checks for description.
     # Default: ["argument", "case", "condition", "operation", "return", "assign"]
     checks:

--- a/k8s_api.go
+++ b/k8s_api.go
@@ -173,7 +173,6 @@ func (kc *K8sClient) GetAllJobsMapped() *protos.MappedJobs {
 
 	jobsMapped := make(map[string][]*batchv1.Job)
 	for _, job := range jobs.Items {
-		job := job
 		for _, owr := range job.ObjectMeta.OwnerReferences {
 			target := jobsMapped[owr.Name]
 			jobsMapped[owr.Name] = append(target, &job)

--- a/sk8l.go
+++ b/sk8l.go
@@ -898,13 +898,14 @@ func (s *Sk8lServer) cronJobResponse(cronJob batchv1.CronJob, jobsForCronjob []*
 
 	return cjr
 }
+
 func collectTerminatedAndFailedContainers(
 	pod *corev1.Pod,
 	statuses []corev1.ContainerStatus,
 	terminationReasons *[]*protos.TerminationReason,
-) ([]*protos.ContainerResponse, []*protos.ContainerResponse) {
-	terminatedContainers := make([]*protos.ContainerResponse, 0)
-	failedContainers := make([]*protos.ContainerResponse, 0)
+) (terminatedContainers []*protos.ContainerResponse, failedContainers []*protos.ContainerResponse) {
+	terminatedContainers = make([]*protos.ContainerResponse, 0)
+	failedContainers = make([]*protos.ContainerResponse, 0)
 
 	for _, containerStatus := range statuses {
 		// ephStates = append(ephStates, container.State)
@@ -964,7 +965,7 @@ func collectTerminatedAndFailedContainers(
 
 func terminatedAndFailedContainersResponses(
 	pod *corev1.Pod,
-) (*protos.TerminatedContainers, *protos.TerminatedContainers) {
+) (terminatedContainersResponse *protos.TerminatedContainers, failedContainersResponse *protos.TerminatedContainers) {
 	terminatedReasons := make([]*protos.TerminationReason, 0)
 
 	terminatedEphContainers, failedEphContainers := collectTerminatedAndFailedContainers(
@@ -983,13 +984,13 @@ func terminatedAndFailedContainersResponses(
 		&terminatedReasons,
 	)
 
-	terminatedContainersResponse := &protos.TerminatedContainers{
+	terminatedContainersResponse = &protos.TerminatedContainers{
 		InitContainers:      terminatedInitContainers,
 		EphemeralContainers: terminatedEphContainers,
 		Containers:          terminatedContainers,
 	}
 
-	failedContainersResponse := &protos.TerminatedContainers{
+	failedContainersResponse = &protos.TerminatedContainers{
 		InitContainers:      failedInitContainers,
 		EphemeralContainers: failedEphContainers,
 		Containers:          failedContainers,

--- a/sk8l.go
+++ b/sk8l.go
@@ -911,11 +911,9 @@ func collectTerminatedAndFailedContainers(
 		// if container.State.Waiting != nil && container.State.Waiting.Reason == "Error" {
 		//      failedEphContainers = append(failedEphContainers, &container)
 		// }
-		containerStatus := containerStatus
 
 		podConditions := []*corev1.PodCondition{}
 		for _, pc := range pod.Status.Conditions {
-			pc := pc
 			podConditions = append(podConditions, &pc)
 		}
 
@@ -1007,7 +1005,6 @@ func buildJobPodsResponses(gJobPods *corev1.PodList) []*protos.PodResponse {
 
 	// ephStates := make([]corev1.ContainerState, 0)
 	for _, pod := range gJobPods.Items {
-		pod := pod
 		// jobPodsForJob.Items[0].Status.ContainerStatuses
 		// jobPodsForJob.Items[0].Status.InitContainerStatuses
 		terminatedContainers, failedContainers := terminatedAndFailedContainersResponses(&pod)


### PR DESCRIPTION
Currently the job fails, the error says that there were no go files to scan.

```
ERRO Running error: context loading failed: no go files to analyze: running `go mod tidy` may solve the problem
ERRO Timeout exceeded: try increasing it by passing --timeout option
```

I reproduced this locally with the v1.57.2.

Trying v1.62.xx for now