### PR TITLE
docker: Save/load dev-pr image instead of pushing/pulling to hub

### DIFF
--- a/.changelog/184.txt
+++ b/.changelog/184.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-gha/docker: Load dev-pr image instead of pushing/pulling to docker hub
+gha/docker: No longer build/push/pull dev-pr version to/from Docker hub, instead export it in the OCI image layout format and load it into kind directly.
 ```

--- a/.changelog/184.txt
+++ b/.changelog/184.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+gha/docker: Load dev-pr image instead of pushing/pulling to docker hub
+```

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,17 +37,35 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push dev version to docker registry
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+      - name: Cache sk8l image
+        id: image-cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          context: .
-          file: Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ vars.DOCKERHUB_SK8L_API_IMAGE_NAME }}:dev-${{ inputs.image_tag }}
+          path: ./sk8l-api:dev-${{ inputs.image_tag }}.tar
+          # The cache key a combination of the current PR number and the commit SHA
+          key: dev-${{ inputs.image_tag }}-${{ github.sha }}
+      - name: Build and save amd64 image
+        run: |
+          docker buildx build --platform linux/amd64 -t danroux/sk8l-api:dev-${{ inputs.image_tag }} --load .
+          docker images
+          docker save danroux/sk8l-api:dev-${{ inputs.image_tag }} -o ./sk8l-api:dev-${{ inputs.image_tag }}.tar
+      # - name: Build and push dev version to docker registry
+      #   uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+      #   with:
+      #     context: .
+      #     file: Dockerfile
+      #     cache-from: type=gha
+      #     cache-to: type=gha,mode=max
+      #     platforms: linux/amd64,linux/arm64
+      #     push: false
+      #     load: true
+      #     outputs: type=cacheonly
+      #     tags: |
+      #       ${{ vars.DOCKERHUB_SK8L_API_IMAGE_NAME }}:dev-${{ github.event.pull_request.number }}
+      # - name: Save Docker image
+      #   run: |
+      #     docker images
+      #     docker save danroux/sk8l-api:dev-${{ inputs.image_tag }} -o ./sk8l-api:dev-${{ inputs.image_tag }}.tar
       - name: Login to ghcr.io
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,13 +37,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Cache sk8l image
+      - name: Cache sk8l-api:dev-${{ inputs.image_tag }}
         id: image-cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ./sk8l-api:dev-${{ inputs.image_tag }}.tar
           key: dev-${{ inputs.image_tag }}-${{ github.sha }}
-      - name: Build sk8l-api:dev-${{ inputs.image_tag }} version
+      - name: Build sk8l-api:dev-${{ inputs.image_tag }}
         if: steps.image-cache.outputs.cache-hit != 'true'
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
@@ -54,7 +54,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: false
           load: false
-          outputs: type=docker,dest=sk8l-api:dev-${{ inputs.image_tag }}.tar
+          outputs: type=oci,dest=sk8l-api:dev-${{ inputs.image_tag }}.tar,tar=true
           tags: |
             ${{ vars.DOCKERHUB_SK8L_API_IMAGE_NAME }}:dev-${{ inputs.image_tag }}
       - name: Login to ghcr.io

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,8 @@ jobs:
         with:
           path: ./sk8l-api:dev-${{ inputs.image_tag }}.tar
           key: dev-${{ inputs.image_tag }}-${{ github.sha }}
-      - name: Build dev version
+      - name: Build sk8l-api:dev-${{ inputs.image_tag }} version
+        if: steps.image-cache.outputs.cache-hit != 'true'
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: .
@@ -52,14 +53,10 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
           push: false
-          load: true
+          load: false
+          outputs: type=docker,dest=sk8l-api:dev-${{ inputs.image_tag }}.tar
           tags: |
             ${{ vars.DOCKERHUB_SK8L_API_IMAGE_NAME }}:dev-${{ inputs.image_tag }}
-      - name: Save amd64 image
-        run: |
-          #     docker buildx build --platform linux/amd64 -t danroux/sk8l-api:dev-${{ inputs.image_tag }} --load .
-          docker images
-          docker save danroux/sk8l-api:dev-${{ inputs.image_tag }} -o ./sk8l-api:dev-${{ inputs.image_tag }}.tar
       - name: Login to ghcr.io
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,30 +42,24 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ./sk8l-api:dev-${{ inputs.image_tag }}.tar
-          # The cache key a combination of the current PR number and the commit SHA
           key: dev-${{ inputs.image_tag }}-${{ github.sha }}
-      - name: Build and save amd64 image
+      - name: Build dev version
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        with:
+          context: .
+          file: Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+          push: false
+          load: true
+          tags: |
+            ${{ vars.DOCKERHUB_SK8L_API_IMAGE_NAME }}:dev-${{ inputs.image_tag }}
+      - name: Save amd64 image
         run: |
-          docker buildx build --platform linux/amd64 -t danroux/sk8l-api:dev-${{ inputs.image_tag }} --load .
+          #     docker buildx build --platform linux/amd64 -t danroux/sk8l-api:dev-${{ inputs.image_tag }} --load .
           docker images
           docker save danroux/sk8l-api:dev-${{ inputs.image_tag }} -o ./sk8l-api:dev-${{ inputs.image_tag }}.tar
-      # - name: Build and push dev version to docker registry
-      #   uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
-      #   with:
-      #     context: .
-      #     file: Dockerfile
-      #     cache-from: type=gha
-      #     cache-to: type=gha,mode=max
-      #     platforms: linux/amd64,linux/arm64
-      #     push: false
-      #     load: true
-      #     outputs: type=cacheonly
-      #     tags: |
-      #       ${{ vars.DOCKERHUB_SK8L_API_IMAGE_NAME }}:dev-${{ github.event.pull_request.number }}
-      # - name: Save Docker image
-      #   run: |
-      #     docker images
-      #     docker save danroux/sk8l-api:dev-${{ inputs.image_tag }} -o ./sk8l-api:dev-${{ inputs.image_tag }}.tar
       - name: Login to ghcr.io
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:

--- a/.github/workflows/k8s-test.yml
+++ b/.github/workflows/k8s-test.yml
@@ -59,6 +59,16 @@ jobs:
       - name: Setup certs
         run: |
           make setup-certs > /dev/null
+      - name: Cache sk8l image
+        id: image-cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ./sk8l-api:dev-${{ inputs.image_tag }}.tar
+          # The cache key a combination of the current PR number and the commit SHA
+          key: dev-${{ inputs.image_tag }}-${{ github.sha }}
+      - name: Load sk8l-api ${{ inputs.image_tag }} image
+        run:
+          kind load image-archive sk8l-api:dev-${{ inputs.image_tag }}.tar -n sk8l-${{ inputs.kind_version }}-${{ inputs.k8s_version }}-${{ inputs.image_tag }}
       - name: Install Chart
         run: |
           make install-chart-ci > /dev/null

--- a/.github/workflows/k8s-test.yml
+++ b/.github/workflows/k8s-test.yml
@@ -59,14 +59,13 @@ jobs:
       - name: Setup certs
         run: |
           make setup-certs > /dev/null
-      - name: Cache sk8l image
+      - name: Fetch sk8l-api:dev-${{ inputs.image_tag }}
         id: image-cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ./sk8l-api:dev-${{ inputs.image_tag }}.tar
-          # The cache key a combination of the current PR number and the commit SHA
           key: dev-${{ inputs.image_tag }}-${{ github.sha }}
-      - name: Load sk8l-api ${{ inputs.image_tag }} image
+      - name: Load sk8l-api:dev-${{ inputs.image_tag }}
         run:
           kind load image-archive sk8l-api:dev-${{ inputs.image_tag }}.tar -n sk8l-${{ inputs.kind_version }}-${{ inputs.k8s_version }}-${{ inputs.image_tag }}
       - name: Install Chart


### PR DESCRIPTION
No longer build/push/pull dev-pr version to/from Docker hub, instead export it in the OCI image layout format and load it into kind directly.