### PR TITLE
ci(k8s): upgrade setup-kind to helm/kind-action@v1.12.0

### DIFF
--- a/.changelog/272.txt
+++ b/.changelog/272.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ci/k8s: Upgrade setup-kind GitHub action from engineerd/setup-kind to helm/kind-action@v1.12.0
+```

--- a/.github/workflows/k8s-test.yml
+++ b/.github/workflows/k8s-test.yml
@@ -42,11 +42,11 @@ jobs:
         run: |
           make update-config-files GITHUB_PR_IMAGE_TAG=dev-${{ inputs.image_tag }}
       - name: Setup Kubernetes cluster ${{ inputs.kind_version }}/${{ inputs.k8s_version }}
-        uses: engineerd/setup-kind@v0.6.2
+        uses: helm/kind-action@v1.12.0
         with:
-          name: "sk8l-${{ inputs.kind_version }}-${{ inputs.k8s_version }}-${{ inputs.image_tag }}"
+          cluster_name: "sk8l-${{ inputs.kind_version }}-${{ inputs.k8s_version }}-${{ inputs.image_tag }}"
           version: ${{ inputs.kind_version }}
-          image: ${{ inputs.k8s_image }}
+          node_image: ${{ inputs.k8s_image }}
           config: testdata/sk8l-kind.yml
       - name: Test connection
         run: |


### PR DESCRIPTION
Replace deprecated engineerd/setup-kind@v0.6.2 action with helm/kind-action@v1.12.0 in the k8s-test workflow. Update action parameters `name` to `cluster_name` and `image` to `node_image` to align with helm/kind-action inputs.