### PR TITLE
go: improve error handling, resilience, and test coverage

### DIFF
--- a/.changelog/274.txt
+++ b/.changelog/274.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+go: Improve error handling, resilience, and test coverage across k8s client, store, watchers, and metrics collection
+```

--- a/internal/dashboard/dashboards_test.go
+++ b/internal/dashboard/dashboards_test.go
@@ -1,0 +1,64 @@
+package dashboard
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestNewGenerator(t *testing.T) {
+	gen := NewGenerator("sk8l_default", "default", []string{"registered_cronjobs_total", "completed_cronjobs_total"})
+	if gen.MetricPrefix != "sk8l_default" {
+		t.Errorf("expected MetricPrefix sk8l_default, got %s", gen.MetricPrefix)
+	}
+	if gen.Namespace != "default" {
+		t.Errorf("expected Namespace default, got %s", gen.Namespace)
+	}
+	if len(gen.TotalMetricNames) != 2 {
+		t.Errorf("expected 2 TotalMetricNames, got %d", len(gen.TotalMetricNames))
+	}
+}
+
+func TestGeneratePanels_EmptyMap(t *testing.T) {
+	totalMetrics := []string{
+		"registered_cronjobs_total",
+		"completed_cronjobs_total",
+		"running_cronjobs_total",
+		"failing_cronjobs_total",
+	}
+	gen := NewGenerator("sk8l_prod", "prod", totalMetrics)
+	m := &sync.Map{}
+
+	panels := gen.GeneratePanels(m)
+	if len(panels) < 5 {
+		t.Errorf("expected at least 5 default overview panels, got %d", len(panels))
+	}
+
+	if panels[0].Type != "row" || panels[0].Title != "sk8l: prod overview" {
+		t.Errorf("unexpected first panel: %+v", panels[0])
+	}
+}
+
+func TestGeneratePanels_WithMetrics(t *testing.T) {
+	totalMetrics := []string{
+		"registered_cronjobs_total",
+		"completed_cronjobs_total",
+	}
+	gen := NewGenerator("sk8l_staging", "staging", totalMetrics)
+	m := &sync.Map{}
+	m.Store("my_cronjob", []string{
+		"sk8l_staging_my_cronjob_completion_total",
+		"sk8l_staging_my_cronjob_failure_total",
+		"sk8l_staging_my_cronjob_duration_seconds",
+	})
+
+	panels := gen.GeneratePanels(m)
+	if len(panels) <= 5 {
+		t.Errorf("expected more than 5 panels with cronjob metrics, got %d", len(panels))
+	}
+
+	// Verify failure legend format
+	legend := failureLegendFmt("sk8l_staging_my_cronjob_failure_total")
+	if legend != "sk8l_staging_my_cronjob" {
+		t.Errorf("expected legend sk8l_staging_my_cronjob, got %q", legend)
+	}
+}

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -4,14 +4,11 @@ package k8s
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -19,13 +16,13 @@ import (
 )
 
 type ClientInterface interface {
-	GetCronjob(ctx context.Context, cronjobNamespace, cronjobName string) *batchv1.CronJob
-	WatchCronjobs(ctx context.Context) watch.Interface
-	WatchJobs(ctx context.Context) watch.Interface
-	WatchPods(ctx context.Context) watch.Interface
-	GetPod(ctx context.Context, jobNamespace, podName string) *corev1.Pod
-	GetJob(ctx context.Context, jobNamespace, jobName string) *batchv1.Job
-	GetAllJobs(ctx context.Context) *batchv1.JobList
+	GetCronjob(ctx context.Context, cronjobNamespace, cronjobName string) (*batchv1.CronJob, error)
+	WatchCronjobs(ctx context.Context) (watch.Interface, error)
+	WatchJobs(ctx context.Context) (watch.Interface, error)
+	WatchPods(ctx context.Context) (watch.Interface, error)
+	GetPod(ctx context.Context, jobNamespace, podName string) (*corev1.Pod, error)
+	GetJob(ctx context.Context, jobNamespace, jobName string) (*batchv1.Job, error)
+	GetAllJobs(ctx context.Context) (*batchv1.JobList, error)
 	Namespace() string
 }
 
@@ -52,20 +49,19 @@ func WithLogger(l zerolog.Logger) ClientOption {
 	}
 }
 
-func NewClient(options ...ClientOption) *Client {
+func NewClient(options ...ClientOption) (*Client, error) {
 	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("in-cluster config failed: %w", err)
+	}
 	config.ContentConfig = rest.ContentConfig{
 		AcceptContentTypes: "application/vnd.kubernetes.protobuf,application/json",
 		ContentType:        "application/vnd.kubernetes.protobuf",
 	}
 
-	if err != nil {
-		panic(err.Error())
-	}
-
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		panic(err.Error())
+		return nil, fmt.Errorf("kubernetes.NewForConfig failed: %w", err)
 	}
 
 	kc := &Client{
@@ -76,7 +72,7 @@ func NewClient(options ...ClientOption) *Client {
 		optionFn(kc)
 	}
 
-	return kc
+	return kc, nil
 }
 
 func NewClientWithInterface(iface kubernetes.Interface, options ...ClientOption) *Client {
@@ -93,108 +89,106 @@ func (kc *Client) Namespace() string {
 	return kc.namespace
 }
 
-func (kc *Client) GetCronjob(ctx context.Context, cronjobNamespace, cronjobName string) *batchv1.CronJob {
+func (kc *Client) GetCronjob(ctx context.Context, cronjobNamespace, cronjobName string) (*batchv1.CronJob, error) {
 	cronJob, err := kc.BatchV1().CronJobs(cronjobNamespace).Get(ctx, cronjobName, metav1.GetOptions{})
-
-	var statusError *k8serrors.StatusError
-	switch {
-	case k8serrors.IsNotFound(err):
+	if err != nil {
 		kc.l.Error().
 			Err(err).
 			Str("operation", "GetCronjob").
-			Msg(fmt.Sprintf("Cronjob %s not found in default namespace", cronjobName))
-	case errors.As(err, &statusError):
-		kc.l.Error().
-			Err(err).
-			Str("operation", "GetCronjob").
-			Msg(fmt.Sprintf("Error getting CronJob %v", statusError.ErrStatus.Message))
-	case err != nil:
-		panic(err.Error())
-	default:
-		kc.l.Info().
-			Str("component", "k8s").
-			Str("operation", "GetCronjob").
-			Msg(fmt.Sprintf("CronJob %s found in %s namespace", cronjobName, cronjobNamespace))
+			Msg(fmt.Sprintf("failed to get CronJob %s in namespace %s", cronjobName, cronjobNamespace))
+		return nil, fmt.Errorf("failed to get CronJob %s in namespace %s: %w", cronjobName, cronjobNamespace, err)
 	}
 
-	return cronJob
+	kc.l.Info().
+		Str("component", "k8s").
+		Str("operation", "GetCronjob").
+		Msg(fmt.Sprintf("CronJob %s found in %s namespace", cronjobName, cronjobNamespace))
+
+	return cronJob, nil
 }
 
-func (kc *Client) WatchCronjobs(ctx context.Context) watch.Interface {
+func (kc *Client) WatchCronjobs(ctx context.Context) (watch.Interface, error) {
 	watcher, err := kc.BatchV1().CronJobs(kc.namespace).Watch(ctx, metav1.ListOptions{})
 	if err != nil {
-		panic(err.Error())
+		kc.l.Error().
+			Err(err).
+			Str("operation", "WatchCronjobs").
+			Msg("failed to start watching CronJobs")
+		return nil, fmt.Errorf("failed to start watching CronJobs: %w", err)
 	}
 
-	return watcher
+	return watcher, nil
 }
 
-func (kc *Client) WatchJobs(ctx context.Context) watch.Interface {
+func (kc *Client) WatchJobs(ctx context.Context) (watch.Interface, error) {
 	watcher, err := kc.BatchV1().Jobs(kc.namespace).Watch(ctx, metav1.ListOptions{})
 	if err != nil {
-		panic(err.Error())
+		kc.l.Error().
+			Err(err).
+			Str("operation", "WatchJobs").
+			Msg("failed to start watching Jobs")
+		return nil, fmt.Errorf("failed to start watching Jobs: %w", err)
 	}
 
-	return watcher
+	return watcher, nil
 }
 
-func (kc *Client) WatchPods(ctx context.Context) watch.Interface {
+func (kc *Client) WatchPods(ctx context.Context) (watch.Interface, error) {
 	watcher, err := kc.CoreV1().Pods(kc.namespace).Watch(ctx, metav1.ListOptions{})
 	if err != nil {
-		panic(err.Error())
+		kc.l.Error().
+			Err(err).
+			Str("operation", "WatchPods").
+			Msg("failed to start watching Pods")
+		return nil, fmt.Errorf("failed to start watching Pods: %w", err)
 	}
 
-	return watcher
+	return watcher, nil
 }
 
-func (kc *Client) GetPod(ctx context.Context, jobNamespace, podName string) *corev1.Pod {
+func (kc *Client) GetPod(ctx context.Context, jobNamespace, podName string) (*corev1.Pod, error) {
 	pod, err := kc.CoreV1().Pods(jobNamespace).Get(ctx, podName, metav1.GetOptions{})
-
-	var statusError *k8serrors.StatusError
-	switch {
-	case k8serrors.IsNotFound(err):
+	if err != nil {
 		kc.l.Error().
 			Err(err).
 			Str("operation", "GetPod").
-			Msg(fmt.Sprintf("Pod %s not found in default namespace", podName))
-	case errors.As(err, &statusError):
-		log.Printf("Error getting Pod %v\n", statusError.ErrStatus.Message)
-		kc.l.Error().
-			Err(err).
-			Str("operation", "GetPod").
-			Msg(fmt.Sprintf("Error getting Pod %v", statusError.ErrStatus.Message))
-	case err != nil:
-		panic(err.Error())
-	default:
-		kc.l.Info().
-			Str("operation", "GetPod").
-			Msg(fmt.Sprintf("Pod %s found in %s namespace", jobNamespace, podName))
+			Msg(fmt.Sprintf("failed to get Pod %s in namespace %s", podName, jobNamespace))
+		return nil, fmt.Errorf("failed to get Pod %s in namespace %s: %w", podName, jobNamespace, err)
 	}
 
-	return pod
+	kc.l.Info().
+		Str("operation", "GetPod").
+		Msg(fmt.Sprintf("Pod %s found in %s namespace", podName, jobNamespace))
+
+	return pod, nil
 }
 
-func (kc *Client) GetJob(ctx context.Context, jobNamespace, jobName string) *batchv1.Job {
+func (kc *Client) GetJob(ctx context.Context, jobNamespace, jobName string) (*batchv1.Job, error) {
 	job, err := kc.BatchV1().Jobs(jobNamespace).Get(ctx, jobName, metav1.GetOptions{})
 	if err != nil {
-		panic(err.Error())
+		kc.l.Error().
+			Err(err).
+			Str("operation", "GetJob").
+			Msg(fmt.Sprintf("failed to get Job %s in namespace %s", jobName, jobNamespace))
+		return nil, fmt.Errorf("failed to get Job %s in namespace %s: %w", jobName, jobNamespace, err)
 	}
 
-	return job
+	return job, nil
 }
 
-func (kc *Client) GetAllJobs(ctx context.Context) *batchv1.JobList {
-	// get pods in all the namespaces by omitting namespace
-	// Or specify namespace to get pods in particular namespace
-	// Limit: 10, // need to fix this - last duration / current duration get messed up
+func (kc *Client) GetAllJobs(ctx context.Context) (*batchv1.JobList, error) {
 	jobs, err := kc.BatchV1().Jobs(kc.namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		panic(err.Error())
+		kc.l.Error().
+			Err(err).
+			Str("operation", "GetAllJobs").
+			Msg("failed to list Jobs")
+		return nil, fmt.Errorf("failed to list Jobs: %w", err)
 	}
 
 	kc.l.Info().
 		Str("operation", "GetAllJobs").
 		Msg(fmt.Sprintf("There are %d jobs in the cluster", len(jobs.Items)))
 
-	return jobs
+	return jobs, nil
 }

--- a/internal/k8s/k8s_test.go
+++ b/internal/k8s/k8s_test.go
@@ -1,0 +1,154 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetCronjob(t *testing.T) {
+	cronjob := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cj",
+			Namespace: "default",
+		},
+	}
+	clientSet := fake.NewClientset(cronjob)
+	client := NewClientWithInterface(clientSet, WithNamespace("default"))
+
+	ctx := context.Background()
+
+	// Found case
+	cj, err := client.GetCronjob(ctx, "default", "test-cj")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cj.Name != "test-cj" {
+		t.Errorf("expected test-cj, got %s", cj.Name)
+	}
+
+	// Not found case
+	_, err = client.GetCronjob(ctx, "default", "non-existent")
+	if err == nil {
+		t.Fatal("expected error for non-existent cronjob, got nil")
+	}
+}
+
+func TestGetJob(t *testing.T) {
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "default",
+		},
+	}
+	clientSet := fake.NewClientset(job)
+	client := NewClientWithInterface(clientSet, WithNamespace("default"))
+
+	ctx := context.Background()
+
+	// Found case
+	j, err := client.GetJob(ctx, "default", "test-job")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if j.Name != "test-job" {
+		t.Errorf("expected test-job, got %s", j.Name)
+	}
+
+	// Not found case
+	_, err = client.GetJob(ctx, "default", "non-existent")
+	if err == nil {
+		t.Fatal("expected error for non-existent job, got nil")
+	}
+}
+
+func TestGetPod(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+	}
+	clientSet := fake.NewClientset(pod)
+	client := NewClientWithInterface(clientSet, WithNamespace("default"))
+
+	ctx := context.Background()
+
+	// Found case
+	p, err := client.GetPod(ctx, "default", "test-pod")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if p.Name != "test-pod" {
+		t.Errorf("expected test-pod, got %s", p.Name)
+	}
+
+	// Not found case
+	_, err = client.GetPod(ctx, "default", "non-existent")
+	if err == nil {
+		t.Fatal("expected error for non-existent pod, got nil")
+	}
+}
+
+func TestGetAllJobs(t *testing.T) {
+	job1 := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "job-1",
+			Namespace: "default",
+		},
+	}
+	job2 := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "job-2",
+			Namespace: "default",
+		},
+	}
+	clientSet := fake.NewClientset(job1, job2)
+	client := NewClientWithInterface(clientSet, WithNamespace("default"))
+
+	ctx := context.Background()
+	jobs, err := client.GetAllJobs(ctx)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(jobs.Items) != 2 {
+		t.Errorf("expected 2 jobs, got %d", len(jobs.Items))
+	}
+}
+
+func TestWatchMethods(t *testing.T) {
+	clientSet := fake.NewClientset()
+	client := NewClientWithInterface(clientSet, WithNamespace("default"))
+
+	ctx := context.Background()
+
+	cjWatcher, err := client.WatchCronjobs(ctx)
+	if err != nil {
+		t.Fatalf("WatchCronjobs failed: %v", err)
+	}
+	cjWatcher.Stop()
+
+	jobWatcher, err := client.WatchJobs(ctx)
+	if err != nil {
+		t.Fatalf("WatchJobs failed: %v", err)
+	}
+	jobWatcher.Stop()
+
+	podWatcher, err := client.WatchPods(ctx)
+	if err != nil {
+		t.Fatalf("WatchPods failed: %v", err)
+	}
+	podWatcher.Stop()
+}
+
+func TestNamespace(t *testing.T) {
+	clientSet := fake.NewClientset()
+	client := NewClientWithInterface(clientSet, WithNamespace("custom-ns"))
+	if client.Namespace() != "custom-ns" {
+		t.Errorf("expected custom-ns, got %s", client.Namespace())
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -30,10 +30,11 @@ const (
 )
 
 var (
-	CronjobsCacheKey   = []byte("sk8l_cronjobs")
-	JobsMappedCacheKey = []byte("sk8l_jobs_mapped")
-	JobsCacheKey       = []byte("sk8l_jobs")
-	k8sSerializer      = k8sproto.NewSerializer(scheme.Scheme, scheme.Scheme)
+	ErrK8sClientRequired = errors.New("NewCronJobDBStore: K8sClient must be provided")
+	CronjobsCacheKey     = []byte("sk8l_cronjobs")
+	JobsMappedCacheKey   = []byte("sk8l_jobs_mapped")
+	JobsCacheKey         = []byte("sk8l_jobs")
+	k8sSerializer        = k8sproto.NewSerializer(scheme.Scheme, scheme.Scheme)
 )
 
 type APICall func() ([]byte, error)
@@ -58,7 +59,7 @@ func NewCronJobDBStore(optsFn ...CronJobDBStoreOptionFn) (*CronJobDBStore, error
 	}
 
 	if cjdbs.K8sClient == nil {
-		return nil, errors.New("NewCronJobDBStore: K8sClient must be provided")
+		return nil, ErrK8sClientRequired
 	}
 
 	if cjdbs.DB == nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -25,7 +25,7 @@ import (
 const (
 	JobPodsKeyFmt  = "jobs_pods_for_job_%s"
 	CronjobsKeyFmt = "sk8l_cronjob_%s_%s"
-	BadgerTTL      = time.Duration(15)
+	BadgerTTL      = 15 * time.Second
 	RefreshSeconds = 10
 )
 
@@ -36,7 +36,7 @@ var (
 	k8sSerializer      = k8sproto.NewSerializer(scheme.Scheme, scheme.Scheme)
 )
 
-type APICall func() []byte
+type APICall func() ([]byte, error)
 
 type CronJobDBStore struct {
 	K8sClient k8s.ClientInterface
@@ -44,58 +44,72 @@ type CronJobDBStore struct {
 	l zerolog.Logger
 }
 
-type CronJobDBStoreOptionFn func(*CronJobDBStore)
+type CronJobDBStoreOptionFn func(*CronJobDBStore) error
 
-func NewCronJobDBStore(optsFn ...CronJobDBStoreOptionFn) *CronJobDBStore {
+func NewCronJobDBStore(optsFn ...CronJobDBStoreOptionFn) (*CronJobDBStore, error) {
 	cjdbs := &CronJobDBStore{
 		l: log.With().Str("component", "db_store").Logger(),
 	}
 
 	for _, opt := range optsFn {
-		opt(cjdbs)
+		if err := opt(cjdbs); err != nil {
+			return nil, err
+		}
 	}
 
 	if cjdbs.K8sClient == nil {
-		cjdbs.l.Fatal().Msg("NewCronJobDBStore: K8sClient must be provided.")
+		return nil, errors.New("NewCronJobDBStore: K8sClient must be provided")
 	}
 
 	if cjdbs.DB == nil {
-		cjdbs.l.Info().Msg("NewCronJobDBStore: DB not provided, setting default one.")
-		dbFn := WithDefaultDB()
-		dbFn(cjdbs)
+		cjdbs.l.Info().Msg("NewCronJobDBStore: DB not provided, setting default one")
+		if err := WithDefaultDB()(cjdbs); err != nil {
+			return nil, err
+		}
 	}
 
-	return cjdbs
+	return cjdbs, nil
 }
 
 func WithDB(db *badger.DB) CronJobDBStoreOptionFn {
-	return func(cjdbs *CronJobDBStore) { cjdbs.DB = db }
+	return func(cjdbs *CronJobDBStore) error {
+		cjdbs.DB = db
+		return nil
+	}
 }
 
-func WithK8sClient(k8sClient *k8s.Client) CronJobDBStoreOptionFn {
-	return func(cjdbs *CronJobDBStore) {
+func WithK8sClient(k8sClient k8s.ClientInterface) CronJobDBStoreOptionFn {
+	return func(cjdbs *CronJobDBStore) error {
 		cjdbs.K8sClient = k8sClient
+		return nil
 	}
 }
 
 func WithDefaultK8sClient(k8sNamespace string) CronJobDBStoreOptionFn {
-	k8sClient := k8s.NewClient(
-		k8s.WithNamespace(k8sNamespace),
-		k8s.WithLogger(log.With().Str("component", "k8s").Logger()),
-	)
-
-	return WithK8sClient(k8sClient)
+	return func(cjdbs *CronJobDBStore) error {
+		k8sClient, err := k8s.NewClient(
+			k8s.WithNamespace(k8sNamespace),
+			k8s.WithLogger(log.With().Str("component", "k8s").Logger()),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create default k8s client: %w", err)
+		}
+		cjdbs.K8sClient = k8sClient
+		return nil
+	}
 }
 
 func WithDefaultDB() CronJobDBStoreOptionFn {
-	badgerLogger := logger.NewBadgerLogger(zerolog.GlobalLevel())
-	badgerOpts := badger.DefaultOptions("/tmp/badger").WithLogger(badgerLogger)
-	db, err := badger.Open(badgerOpts)
-	if err != nil {
-		badgerLogger.Fatal().Err(err).Msg("failed to open Badger DB")
+	return func(cjdbs *CronJobDBStore) error {
+		badgerLogger := logger.NewBadgerLogger(zerolog.GlobalLevel())
+		badgerOpts := badger.DefaultOptions("/tmp/badger").WithLogger(badgerLogger)
+		db, err := badger.Open(badgerOpts)
+		if err != nil {
+			return fmt.Errorf("failed to open Badger DB: %w", err)
+		}
+		cjdbs.DB = db
+		return nil
 	}
-
-	return WithDB(db)
 }
 
 func (c *CronJobDBStore) GetAndStore(key []byte, apiCall APICall) ([]byte, error) {
@@ -103,8 +117,11 @@ func (c *CronJobDBStore) GetAndStore(key []byte, apiCall APICall) ([]byte, error
 	err := c.DB.Update(func(txn *badger.Txn) error {
 		item, err := txn.Get(key)
 		if errors.Is(err, badger.ErrKeyNotFound) {
-			apiResult := apiCall()
-			entry := badger.NewEntry(key, apiResult).WithTTL(time.Second * BadgerTTL)
+			apiResult, err := apiCall()
+			if err != nil {
+				return fmt.Errorf("apiCall failed: %w", err)
+			}
+			entry := badger.NewEntry(key, apiResult).WithTTL(BadgerTTL)
 			if err = txn.SetEntry(entry); err != nil {
 				c.l.Error().Err(err).Msg("Error: getAndStore#txn.SetEntry")
 				return fmt.Errorf("sk8l#getAndStore: txn.SetEntry() failed: %w", err)
@@ -176,14 +193,17 @@ func (c *CronJobDBStore) FindCronjobs() (*batchv1.CronJobList, error) {
 }
 
 func (c *CronJobDBStore) FindCronjob(ctx context.Context, cronjobNamespace, cronjobName string) (*batchv1.CronJob, error) {
-	gCjCall := func() []byte {
-		cronjob := c.K8sClient.GetCronjob(ctx, cronjobNamespace, cronjobName)
+	gCjCall := func() ([]byte, error) {
+		cronjob, err := c.K8sClient.GetCronjob(ctx, cronjobNamespace, cronjobName)
+		if err != nil {
+			return nil, fmt.Errorf("GetCronjob failed: %w", err)
+		}
 		var buf bytes.Buffer
 		if err := k8sSerializer.Encode(cronjob, &buf); err != nil {
 			c.l.Error().Err(err).Msg("findCronjob#k8sSerializer.Encode")
-			return nil
+			return nil, fmt.Errorf("k8sSerializer.Encode failed: %w", err)
 		}
-		return buf.Bytes()
+		return buf.Bytes(), nil
 	}
 
 	cacheKey := []byte(fmt.Sprintf(CronjobsKeyFmt, cronjobNamespace, cronjobName))
@@ -216,16 +236,20 @@ func (c *CronJobDBStore) FindJobs() (*batchv1.JobList, error) {
 }
 
 func (c *CronJobDBStore) FindJobsMapped(ctx context.Context) (map[string][]*batchv1.Job, error) {
-	jobs, err := c.GetAndStore(JobsMappedCacheKey, func() []byte {
-		jobList := c.K8sClient.GetAllJobs(ctx)
+	jobs, err := c.GetAndStore(JobsMappedCacheKey, func() ([]byte, error) {
+		jobList, err := c.K8sClient.GetAllJobs(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("GetAllJobs failed: %w", err)
+		}
 		var buf bytes.Buffer
 		if err := k8sSerializer.Encode(jobList, &buf); err != nil {
 			log.Error().
 				Err(err).
 				Str("operation", "FindJobsMapped").
 				Msg("k8sSerializer.Encode")
+			return nil, fmt.Errorf("k8sSerializer.Encode failed: %w", err)
 		}
-		return buf.Bytes()
+		return buf.Bytes(), nil
 	})
 
 	if err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -30,10 +31,10 @@ func setupTestDB(t *testing.T) *badger.DB {
 func TestNewCronJobDBStore_Validation(t *testing.T) {
 	db := setupTestDB(t)
 
-	// Missing K8sClient must return error
+	// Missing K8sClient must return ErrK8sClientRequired
 	_, err := NewCronJobDBStore(WithDB(db))
-	if err == nil {
-		t.Fatal("expected error when K8sClient is missing, got nil")
+	if !errors.Is(err, ErrK8sClientRequired) {
+		t.Fatalf("expected ErrK8sClientRequired, got %v", err)
 	}
 
 	// Valid setup

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,252 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/danroux/sk8l/internal/k8s"
+	badger "github.com/dgraph-io/badger/v4"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func setupTestDB(t *testing.T) *badger.DB {
+	t.Helper()
+	opts := badger.DefaultOptions("").WithInMemory(true).WithLoggingLevel(badger.ERROR)
+	db, err := badger.Open(opts)
+	if err != nil {
+		t.Fatalf("failed to open test badger DB: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	return db
+}
+
+func TestNewCronJobDBStore_Validation(t *testing.T) {
+	db := setupTestDB(t)
+
+	// Missing K8sClient must return error
+	_, err := NewCronJobDBStore(WithDB(db))
+	if err == nil {
+		t.Fatal("expected error when K8sClient is missing, got nil")
+	}
+
+	// Valid setup
+	fakeClientset := fake.NewClientset()
+	k8sClient := k8s.NewClientWithInterface(fakeClientset)
+	store, err := NewCronJobDBStore(WithDB(db), WithK8sClient(k8sClient))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if store == nil {
+		t.Fatal("expected non-nil store")
+	}
+}
+
+func TestFindCronjobs(t *testing.T) {
+	db := setupTestDB(t)
+	fakeClientset := fake.NewClientset()
+	k8sClient := k8s.NewClientWithInterface(fakeClientset)
+	s, err := NewCronJobDBStore(WithDB(db), WithK8sClient(k8sClient))
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	// Empty store should return empty CronJobList
+	list, err := s.FindCronjobs()
+	if err != nil {
+		t.Fatalf("expected no error on empty store, got %v", err)
+	}
+	if len(list.Items) != 0 {
+		t.Errorf("expected 0 items, got %d", len(list.Items))
+	}
+
+	// Store cronjobs and retrieve
+	cjList := &batchv1.CronJobList{
+		Items: []batchv1.CronJob{
+			{ObjectMeta: metav1.ObjectMeta{Name: "cj-1", Namespace: "default"}},
+		},
+	}
+	var buf bytes.Buffer
+	if err := K8sSerialize(cjList, &buf); err != nil {
+		t.Fatalf("failed to serialize: %v", err)
+	}
+
+	err = db.Update(func(txn *badger.Txn) error {
+		return txn.Set(CronjobsCacheKey, buf.Bytes())
+	})
+	if err != nil {
+		t.Fatalf("failed to set cache: %v", err)
+	}
+
+	retrieved, err := s.FindCronjobs()
+	if err != nil {
+		t.Fatalf("expected no error retrieving cronjobs, got %v", err)
+	}
+	if len(retrieved.Items) != 1 || retrieved.Items[0].Name != "cj-1" {
+		t.Errorf("expected cj-1, got %+v", retrieved.Items)
+	}
+}
+
+func TestFindCronjob(t *testing.T) {
+	db := setupTestDB(t)
+	cj := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "cj-fallback", Namespace: "default"},
+	}
+	fakeClientset := fake.NewClientset(cj)
+	k8sClient := k8s.NewClientWithInterface(fakeClientset)
+	s, err := NewCronJobDBStore(WithDB(db), WithK8sClient(k8sClient))
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	ctx := context.Background()
+	found, err := s.FindCronjob(ctx, "default", "cj-fallback")
+	if err != nil {
+		t.Fatalf("expected fallback to k8s client, got error: %v", err)
+	}
+	if found.Name != "cj-fallback" {
+		t.Errorf("expected cj-fallback, got %s", found.Name)
+	}
+}
+
+func TestFindJobs(t *testing.T) {
+	db := setupTestDB(t)
+	fakeClientset := fake.NewClientset()
+	k8sClient := k8s.NewClientWithInterface(fakeClientset)
+	s, err := NewCronJobDBStore(WithDB(db), WithK8sClient(k8sClient))
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	list, err := s.FindJobs()
+	if err != nil {
+		t.Fatalf("expected no error on empty store, got %v", err)
+	}
+	if len(list.Items) != 0 {
+		t.Errorf("expected 0 items, got %d", len(list.Items))
+	}
+}
+
+func TestFindJobsMapped(t *testing.T) {
+	db := setupTestDB(t)
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job-1",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{Name: "parent-cronjob"},
+			},
+		},
+	}
+	fakeClientset := fake.NewClientset(job)
+	k8sClient := k8s.NewClientWithInterface(fakeClientset, k8s.WithNamespace("default"))
+	s, err := NewCronJobDBStore(WithDB(db), WithK8sClient(k8sClient))
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	ctx := context.Background()
+	mapped, err := s.FindJobsMapped(ctx)
+	if err != nil {
+		t.Fatalf("expected no error from FindJobsMapped, got %v", err)
+	}
+	jobs, ok := mapped["parent-cronjob"]
+	if !ok || len(jobs) != 1 {
+		t.Fatalf("expected 1 job for parent-cronjob, got %v", jobs)
+	}
+	if jobs[0].Name != "test-job-1" {
+		t.Errorf("expected test-job-1, got %s", jobs[0].Name)
+	}
+}
+
+func TestFindJobPodsForJob(t *testing.T) {
+	db := setupTestDB(t)
+	fakeClientset := fake.NewClientset()
+	k8sClient := k8s.NewClientWithInterface(fakeClientset)
+	s, err := NewCronJobDBStore(WithDB(db), WithK8sClient(k8sClient))
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "my-job"}}
+
+	// No pods stored yet
+	pods, err := s.FindJobPodsForJob(job)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(pods.Items) != 0 {
+		t.Errorf("expected 0 pods, got %d", len(pods.Items))
+	}
+
+	now := metav1.NewTime(time.Now())
+	podList := &corev1.PodList{
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "pod-v1",
+					ResourceVersion: "1",
+					OwnerReferences: []metav1.OwnerReference{{Name: "my-job"}},
+				},
+				Status: corev1.PodStatus{StartTime: &now},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "pod-v1",
+					ResourceVersion: "2",
+					OwnerReferences: []metav1.OwnerReference{{Name: "my-job"}},
+				},
+				Status: corev1.PodStatus{StartTime: &now},
+			},
+		},
+	}
+	var buf bytes.Buffer
+	if err := K8sSerialize(podList, &buf); err != nil {
+		t.Fatalf("serialize failed: %v", err)
+	}
+
+	key := []byte("jobs_pods_for_job_my-job")
+	err = db.Update(func(txn *badger.Txn) error {
+		return txn.Set(key, buf.Bytes())
+	})
+	if err != nil {
+		t.Fatalf("failed to set pods in badger: %v", err)
+	}
+
+	pods, err = s.FindJobPodsForJob(job)
+	if err != nil {
+		t.Fatalf("FindJobPodsForJob failed: %v", err)
+	}
+	if len(pods.Items) != 1 {
+		t.Fatalf("expected 1 latest pod, got %d", len(pods.Items))
+	}
+	if pods.Items[0].ResourceVersion != "2" {
+		t.Errorf("expected ResourceVersion 2, got %s", pods.Items[0].ResourceVersion)
+	}
+}
+
+func TestK8sSerializeAndDeserialize(t *testing.T) {
+	cj := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "serialize-test", Namespace: "default"},
+	}
+	var buf bytes.Buffer
+	if err := K8sSerialize(cj, &buf); err != nil {
+		t.Fatalf("K8sSerialize failed: %v", err)
+	}
+
+	target := &batchv1.CronJob{}
+	obj, _, err := K8sDeserialize(buf.Bytes(), target)
+	if err != nil {
+		t.Fatalf("K8sDeserialize failed: %v", err)
+	}
+	decoded, ok := obj.(*batchv1.CronJob)
+	if !ok || decoded.Name != "serialize-test" {
+		t.Errorf("expected decoded cronjob serialize-test, got %+v", decoded)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -100,6 +100,24 @@ func main() {
 	}
 	log.Info().
 		Msg(fmt.Sprintf("Starting %s server %s on %s", "sk8l", Version(), ln.Addr().String()))
+	errCh := startServers(httpS, probeS, grpcS, ln, healthLn)
+	metricsCxt, metricsCancel := context.WithCancel(rootCtx)
+	sk8lServer.Run(metricsCxt)
+	log.Info().Msg("Shutdown: setting up")
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
+	select {
+	case err := <-errCh:
+		log.Error().Err(err).
+			Msg("Shutdown: sk8l shutting down... got error during server startup")
+	case sig := <-quit:
+		log.Info().
+			Msg(fmt.Sprintf("Shutdown: Got %v signal. sk8l will shut down shortly", sig))
+	}
+	shutdownServers(rootCtx, httpS, grpcS, probeS, metricsCancel)
+}
+
+func startServers(httpS *http.Server, probeS, grpcS *grpc.Server, ln, healthLn net.Listener) <-chan error {
 	errCh := make(chan error, 3)
 	go func() {
 		if err := httpS.ListenAndServeTLS(certFile, certKeyFile); err != nil {
@@ -116,19 +134,15 @@ func main() {
 			errCh <- fmt.Errorf("grpcS error: %w", err)
 		}
 	}()
-	metricsCxt, metricsCancel := context.WithCancel(rootCtx)
-	sk8lServer.Run(metricsCxt)
-	log.Info().Msg("Shutdown: setting up")
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
-	select {
-	case err := <-errCh:
-		log.Error().Err(err).
-			Msg("Shutdown: sk8l shutting down... got error during server startup")
-	case sig := <-quit:
-		log.Info().
-			Msg(fmt.Sprintf("Shutdown: Got %v signal. sk8l will shut down shortly", sig))
-	}
+	return errCh
+}
+
+func shutdownServers(
+	rootCtx context.Context,
+	httpS *http.Server,
+	grpcS, probeS *grpc.Server,
+	metricsCancel context.CancelFunc,
+) {
 	shutdownCtx, shutdownCancel := context.WithTimeout(rootCtx, 5*time.Second)
 	defer shutdownCancel()
 	if err := httpS.Shutdown(shutdownCtx); err != nil {

--- a/main.go
+++ b/main.go
@@ -28,8 +28,8 @@ import (
 const (
 	ReadTimeoutSeconds  = 10
 	WriteTimeoutSeconds = 30
-	ReadTimeout         = time.Duration(ReadTimeoutSeconds)
-	WriteTimeout        = time.Duration(WriteTimeoutSeconds)
+	ReadTimeout         = ReadTimeoutSeconds * time.Second
+	WriteTimeout        = WriteTimeoutSeconds * time.Second
 )
 
 var (
@@ -74,7 +74,10 @@ func main() {
 		TotalMetricNames,
 	)
 
-	cronjobDBStore := store.NewCronJobDBStore(store.WithDefaultK8sClient(K8Namespace))
+	cronjobDBStore, err := store.NewCronJobDBStore(store.WithDefaultK8sClient(K8Namespace))
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to initialize cronjobDBStore")
+	}
 	sk8lServer := NewSk8lServer(
 		target,
 		cronjobDBStore,
@@ -90,8 +93,8 @@ func main() {
 	httpS := &http.Server{
 		Addr:         fmt.Sprintf("0.0.0.0:%s", MetricsPort),
 		IdleTimeout:  time.Minute,
-		ReadTimeout:  ReadTimeout * time.Second,
-		WriteTimeout: WriteTimeout * time.Second,
+		ReadTimeout:  ReadTimeout,
+		WriteTimeout: WriteTimeout,
 		TLSConfig:    serverTLSConfig,
 		Handler:      mux,
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -48,19 +48,7 @@ var (
 	completedCronjobsGauge  = promauto.NewGauge(completedCronjobsOpts)
 	registeredCronjobsGauge = promauto.NewGauge(registeredCronjobsOpts)
 
-	cronjobFailingJobs     float64
-	cronjobCompletions     float64
-	completedCronjobs      float64
-	jobDuration            float64
-	failingJobs            float64
-	runningCronjobs        float64
-	cronjobCompletionsOpts prometheus.GaugeOpts
-	cronjobDurationOpts    prometheus.GaugeOpts
-	failingJobsOpts        prometheus.GaugeOpts
-	completionsKey         string
-	durationKey            string
-	failuresKey            string
-	metricNameRegex        = regexp.MustCompile(`_*[^0-9A-Za-z_]+_*`)
+	metricNameRegex = regexp.MustCompile(`_*[^0-9A-Za-z_]+_*`)
 
 	TotalMetricNames = []string{
 		registeredCronjobsOpts.Name,
@@ -69,6 +57,166 @@ var (
 		failingCronjobsOpts.Name,
 	}
 )
+
+func setGaugeInMap(key string, opts prometheus.GaugeOpts, val float64) {
+	if gauge, ok := summaryMap.Load(key); ok {
+		gauge.(prometheus.Gauge).Set(val)
+		return
+	}
+	newGauge := promauto.NewGauge(opts)
+	summaryMap.Store(key, newGauge)
+	newGauge.Set(val)
+}
+
+// Computes job duration and sets the per-job duration gauge.
+func recordJobDuration(job *protos.JobResponse, sanitizedCjName, durationMetricName, subSystem string) (isFailed bool, isCompleted bool) {
+	if job.Failed {
+		isFailed = true
+	}
+	if job.Status != nil && job.Status.CompletionTime != "" {
+		isCompleted = true
+	}
+
+	sanitizedJobName := job.Name
+	labels := prometheus.Labels{"job_name": sanitizedJobName}
+	opts := prometheus.GaugeOpts{
+		Name:        durationMetricName,
+		Namespace:   optNamespace,
+		Subsystem:   subSystem,
+		Help:        fmt.Sprintf("Duration of %s in seconds", sanitizedCjName),
+		ConstLabels: labels,
+	}
+	durationKey := fmt.Sprintf(
+		"%s_%s_%s_%s_durations",
+		opts.Namespace,
+		opts.Subsystem,
+		sanitizedCjName,
+		sanitizedJobName,
+	)
+
+	var duration float64
+	if job.Status != nil && job.Status.Active > 0 {
+		duration = float64(job.DurationInS)
+	}
+	setGaugeInMap(durationKey, opts, duration)
+	return isFailed, isCompleted
+}
+
+// Sets the completion and failure gauges for a specific cronjob and stores metric names in metricsNamesMap.
+func recordSingleCronjobMetrics(
+	cj *protos.CronjobResponse,
+	subSystem string,
+	metricsNamesMap *sync.Map,
+) (running float64, failing float64, completed float64) {
+	sanitizedCjName := sanitizeMetricName(cj.Name)
+	running = float64(len(cj.RunningJobs))
+
+	completionMetricName := fmt.Sprintf("%s_completion_total", sanitizedCjName)
+	failureMetricName := fmt.Sprintf("%s_failure_total", sanitizedCjName)
+	durationMetricName := fmt.Sprintf("%s_duration_seconds", sanitizedCjName)
+
+	metricNames := []string{
+		fmt.Sprintf("%s_%s", MetricPrefix, completionMetricName),
+		fmt.Sprintf("%s_%s", MetricPrefix, failureMetricName),
+		fmt.Sprintf("%s_%s", MetricPrefix, durationMetricName),
+	}
+	metricsNamesMap.Store(sanitizedCjName, metricNames)
+
+	var cronjobFailingJobs, cronjobCompletions float64
+	for _, job := range cj.Jobs {
+		isFailed, isCompleted := recordJobDuration(job, sanitizedCjName, durationMetricName, subSystem)
+		if isFailed {
+			cronjobFailingJobs++
+		}
+		if isCompleted {
+			cronjobCompletions++
+		}
+	}
+
+	completionOpts := prometheus.GaugeOpts{
+		Name:      completionMetricName,
+		Namespace: optNamespace,
+		Subsystem: subSystem,
+		Help:      fmt.Sprintf("%s completion total", sanitizedCjName),
+	}
+	completionsKey := fmt.Sprintf(
+		"%s_%s_%s_completions",
+		completionOpts.Namespace,
+		completionOpts.Subsystem,
+		sanitizedCjName,
+	)
+	setGaugeInMap(completionsKey, completionOpts, cronjobCompletions)
+
+	failureOpts := prometheus.GaugeOpts{
+		Name:      failureMetricName,
+		Namespace: optNamespace,
+		Subsystem: subSystem,
+		Help:      fmt.Sprintf("%s failure total", sanitizedCjName),
+	}
+	failuresKey := fmt.Sprintf(
+		"%s_%s_%s_failures",
+		failureOpts.Namespace,
+		failureOpts.Subsystem,
+		sanitizedCjName,
+	)
+	setGaugeInMap(failuresKey, failureOpts, cronjobFailingJobs)
+
+	return running, cronjobFailingJobs, cronjobCompletions
+}
+
+// Aggregates totals (running, failing, completed, registered) and updates the global gauges.
+func processCronjobsResponse(cronjobs []*protos.CronjobResponse, subSystem string, metricsNamesMap *sync.Map) {
+	registeredCronjobsGauge.Set(float64(len(cronjobs)))
+
+	var totalRunning, totalFailing, totalCompleted float64
+	for _, cj := range cronjobs {
+		running, failing, completed := recordSingleCronjobMetrics(cj, subSystem, metricsNamesMap)
+		totalRunning += running
+		totalFailing += failing
+		totalCompleted += completed
+	}
+
+	runningCronjobsGauge.Set(totalRunning)
+	failingCronjobsGauge.Set(totalFailing)
+	completedCronjobsGauge.Set(totalCompleted)
+}
+
+func collectMetricsStream(ctx context.Context, c protos.CronjobClient, subSystem string, metricsNamesMap *sync.Map) error {
+	cronjobsClient, err := c.GetCronjobs(ctx, &protos.CronjobsRequest{})
+	if err != nil {
+		return fmt.Errorf("c.GetCronjobs failed: %w", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("metrics collection canceled: %w", ctx.Err())
+		default:
+		}
+
+		cronjobsResponse, err := cronjobsClient.Recv()
+		if errors.Is(err, io.EOF) {
+			log.Info().
+				Str("component", "metrics").
+				Msg("GetCronjobs stream closed (EOF), reconnecting")
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("cronjobsClient.Recv() failed: %w", err)
+		}
+		if cronjobsResponse == nil {
+			continue
+		}
+
+		processCronjobsResponse(cronjobsResponse.Cronjobs, subSystem, metricsNamesMap)
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("metrics collection canceled: %w", ctx.Err())
+		case <-time.After(10 * time.Second):
+		}
+	}
+}
 
 func recordMetrics(ctx context.Context, svr *Sk8lServer, metricsNamesMap *sync.Map) {
 	conn, err := grpc.NewClient(svr.GetTarget(), svr.GetDialOptions()...)
@@ -103,177 +251,18 @@ func recordMetrics(ctx context.Context, svr *Sk8lServer, metricsNamesMap *sync.M
 			default:
 			}
 
-			req := &protos.CronjobsRequest{}
-			cronjobsClient, err := c.GetCronjobs(ctx, req)
-			if err != nil {
+			if err := collectMetricsStream(ctx, c, subSystem, metricsNamesMap); err != nil {
+				if errors.Is(err, context.Canceled) {
+					return
+				}
 				log.Error().
 					Err(err).
 					Str("operation", "recordMetrics").
-					Msg("c.GetCronjobs failed, retrying in 5s")
+					Msg("metrics collection error, retrying in 5s")
 				select {
 				case <-ctx.Done():
 					return
 				case <-time.After(5 * time.Second):
-					continue
-				}
-			}
-
-			for {
-				select {
-				case <-ctx.Done():
-					log.Info().
-						Str("component", "metrics").
-						Msg("Stopping metrics collection")
-					return
-				default:
-				}
-
-				cronjobsResponse, err := cronjobsClient.Recv()
-				if errors.Is(err, io.EOF) {
-					log.Info().
-						Str("component", "metrics").
-						Msg("GetCronjobs stream closed (EOF), reconnecting")
-					break
-				}
-				if err != nil {
-					log.Error().
-						Err(err).
-						Str("operation", "recordMetrics").
-						Msg("cronjobsClient.Recv() failed, reconnecting in 5s")
-					select {
-					case <-ctx.Done():
-						return
-					case <-time.After(5 * time.Second):
-					}
-					break
-				}
-				if cronjobsResponse == nil {
-					continue
-				}
-
-				registeredCronjobs := len(cronjobsResponse.Cronjobs)
-				registeredCronjobsGauge.Set(float64(registeredCronjobs))
-				var metricNames []string
-
-				for _, cj := range cronjobsResponse.Cronjobs {
-					sanitizedCjName := sanitizeMetricName(cj.Name)
-					runningCronjobs += float64(len(cj.RunningJobs))
-
-					completionMetricName := fmt.Sprintf("%s_completion_total", sanitizedCjName)
-					failureMetricName := fmt.Sprintf("%s_failure_total", sanitizedCjName)
-					durationMetricName := fmt.Sprintf("%s_duration_seconds", sanitizedCjName)
-
-					metricNames = []string{
-						fmt.Sprintf("%s_%s", MetricPrefix, completionMetricName),
-						fmt.Sprintf("%s_%s", MetricPrefix, failureMetricName),
-						fmt.Sprintf("%s_%s", MetricPrefix, durationMetricName),
-					}
-					metricsNamesMap.Store(sanitizedCjName, metricNames)
-
-					for _, job := range cj.Jobs {
-						if job.Failed {
-							cronjobFailingJobs++
-						}
-
-						if job.Status.CompletionTime != "" {
-							cronjobCompletions++
-						}
-
-						sanitizedJobName := job.Name
-						labels := prometheus.Labels{}
-						labels["job_name"] = sanitizedJobName
-						cronjobDurationOpts = prometheus.GaugeOpts{
-							Name:        durationMetricName,
-							Namespace:   optNamespace,
-							Subsystem:   subSystem,
-							Help:        fmt.Sprintf("Duration of %s in seconds", sanitizedCjName),
-							ConstLabels: labels,
-						}
-						durationKey = fmt.Sprintf(
-							"%s_%s_%s_%s_durations",
-							cronjobDurationOpts.Namespace,
-							cronjobDurationOpts.Subsystem,
-							sanitizedCjName,
-							sanitizedJobName,
-						)
-
-						if job.Status.Active > 0 {
-							jobDuration = float64(job.DurationInS)
-						} else {
-							jobDuration = float64(0)
-						}
-
-						if jobsDurationssGauge, ok := summaryMap.Load(durationKey); ok {
-							jobsDurationssGauge.(prometheus.Gauge).Set(jobDuration)
-						} else {
-							jobsDurationssGauge := promauto.NewGauge(cronjobDurationOpts)
-							summaryMap.Store(durationKey, jobsDurationssGauge)
-							jobsDurationssGauge.Set(jobDuration)
-						}
-					}
-
-					cronjobCompletionsOpts = prometheus.GaugeOpts{
-						Name:      completionMetricName,
-						Namespace: optNamespace,
-						Subsystem: subSystem,
-						Help:      fmt.Sprintf("%s completion total", sanitizedCjName),
-					}
-
-					completionsKey = fmt.Sprintf(
-						"%s_%s_%s_completions",
-						cronjobCompletionsOpts.Namespace,
-						cronjobCompletionsOpts.Subsystem,
-						sanitizedCjName,
-					)
-
-					if cronjobCompletionsGauge, ok := summaryMap.Load(completionsKey); ok {
-						cronjobCompletionsGauge.(prometheus.Gauge).Set(cronjobCompletions)
-					} else {
-						cronjobCompletionsGauge := promauto.NewGauge(cronjobCompletionsOpts)
-						summaryMap.Store(completionsKey, cronjobCompletionsGauge)
-						cronjobCompletionsGauge.Set(cronjobCompletions)
-					}
-
-					failingJobsOpts = prometheus.GaugeOpts{
-						Name:      failureMetricName,
-						Namespace: optNamespace,
-						Subsystem: subSystem,
-						Help:      fmt.Sprintf("%s failure total", sanitizedCjName),
-					}
-
-					failuresKey = fmt.Sprintf(
-						"%s_%s_%s_failures",
-						failingJobsOpts.Namespace,
-						failingJobsOpts.Subsystem,
-						sanitizedCjName,
-					)
-
-					if failingJobsGauge, ok := summaryMap.Load(failuresKey); ok {
-						failingJobsGauge.(prometheus.Gauge).Set(cronjobFailingJobs)
-					} else {
-						failingJobsGauge := promauto.NewGauge(failingJobsOpts)
-						summaryMap.Store(failuresKey, failingJobsGauge)
-						failingJobsGauge.Set(cronjobFailingJobs)
-					}
-
-					failingJobs += cronjobFailingJobs
-					completedCronjobs += cronjobCompletions
-					cronjobFailingJobs = 0
-					cronjobCompletions = 0
-				}
-
-				runningCronjobsGauge.Set(runningCronjobs)
-				failingCronjobsGauge.Set(failingJobs)
-				completedCronjobsGauge.Set(completedCronjobs)
-
-				failingJobs = 0
-				runningCronjobs = 0
-				completedCronjobs = 0
-
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(10 * time.Second):
 				}
 			}
 		}

--- a/metrics.go
+++ b/metrics.go
@@ -73,7 +73,11 @@ var (
 func recordMetrics(ctx context.Context, svr *Sk8lServer, metricsNamesMap *sync.Map) {
 	conn, err := grpc.NewClient(svr.GetTarget(), svr.GetDialOptions()...)
 	if err != nil {
-		panic(fmt.Sprintf("grpc.NewClient(%s) failed: %v", svr.GetTarget(), err))
+		log.Error().
+			Err(err).
+			Str("operation", "recordMetrics").
+			Msg(fmt.Sprintf("grpc.NewClient(%s) failed", svr.GetTarget()))
+		return
 	}
 
 	c := protos.NewCronjobClient(conn)
@@ -83,14 +87,12 @@ func recordMetrics(ctx context.Context, svr *Sk8lServer, metricsNamesMap *sync.M
 		Str("component", "metrics").
 		Str("operation", "recordMetrics").
 		Msg("Starting metrics collection")
-	req := &protos.CronjobsRequest{}
-	cronjobsClient, err := c.GetCronjobs(ctx, req)
-
-	if err != nil {
-		panic(err)
-	}
 
 	go func() {
+		defer func() {
+			_ = conn.Close()
+		}()
+
 		for {
 			select {
 			case <-ctx.Done():
@@ -99,17 +101,54 @@ func recordMetrics(ctx context.Context, svr *Sk8lServer, metricsNamesMap *sync.M
 					Msg("Stopping metrics collection")
 				return
 			default:
-				cronjobsResponse, err := cronjobsClient.Recv()
+			}
 
-				if errors.Is(err, io.EOF) {
-					break
+			req := &protos.CronjobsRequest{}
+			cronjobsClient, err := c.GetCronjobs(ctx, req)
+			if err != nil {
+				log.Error().
+					Err(err).
+					Str("operation", "recordMetrics").
+					Msg("c.GetCronjobs failed, retrying in 5s")
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(5 * time.Second):
+					continue
+				}
+			}
+
+			for {
+				select {
+				case <-ctx.Done():
+					log.Info().
+						Str("component", "metrics").
+						Msg("Stopping metrics collection")
+					return
+				default:
 				}
 
+				cronjobsResponse, err := cronjobsClient.Recv()
+				if errors.Is(err, io.EOF) {
+					log.Info().
+						Str("component", "metrics").
+						Msg("GetCronjobs stream closed (EOF), reconnecting")
+					break
+				}
 				if err != nil {
 					log.Error().
 						Err(err).
 						Str("operation", "recordMetrics").
-						Msg("cronjobsClient = c.GetCronjobs.Recv()")
+						Msg("cronjobsClient.Recv() failed, reconnecting in 5s")
+					select {
+					case <-ctx.Done():
+						return
+					case <-time.After(5 * time.Second):
+					}
+					break
+				}
+				if cronjobsResponse == nil {
+					continue
 				}
 
 				registeredCronjobs := len(cronjobsResponse.Cronjobs)
@@ -230,7 +269,12 @@ func recordMetrics(ctx context.Context, svr *Sk8lServer, metricsNamesMap *sync.M
 				failingJobs = 0
 				runningCronjobs = 0
 				completedCronjobs = 0
-				time.Sleep(10 * time.Second)
+
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(10 * time.Second):
+				}
 			}
 		}
 	}()

--- a/sk8l.go
+++ b/sk8l.go
@@ -264,7 +264,10 @@ func (s *Sk8lServer) GetCronjobYAML(
 	ctx context.Context,
 	in *protos.CronjobRequest,
 ) (*protos.CronjobYAMLResponse, error) {
-	cronjob := s.K8sClient.GetCronjob(ctx, in.CronjobNamespace, in.CronjobName)
+	cronjob, err := s.K8sClient.GetCronjob(ctx, in.CronjobNamespace, in.CronjobName)
+	if err != nil {
+		return nil, fmt.Errorf("sk8l#GetCronjobYAML: %w", err)
+	}
 	prettyJSON, err := json.MarshalIndent(cronjob, "", "  ")
 
 	if err != nil {
@@ -272,6 +275,7 @@ func (s *Sk8lServer) GetCronjobYAML(
 			Err(err).
 			Str("operation", "sk8l#GetCronjobYAML").
 			Msg("json.MarshalIndent() failed")
+		return nil, fmt.Errorf("sk8l#GetCronjobYAML: json.MarshalIndent failed: %w", err)
 	}
 
 	y, _ := gyaml.JSONToYAML(prettyJSON)
@@ -284,7 +288,10 @@ func (s *Sk8lServer) GetCronjobYAML(
 }
 
 func (s *Sk8lServer) GetJobYAML(ctx context.Context, in *protos.JobRequest) (*protos.JobYAMLResponse, error) {
-	job := s.K8sClient.GetJob(ctx, in.JobNamespace, in.JobName)
+	job, err := s.K8sClient.GetJob(ctx, in.JobNamespace, in.JobName)
+	if err != nil {
+		return nil, fmt.Errorf("sk8l#GetJobYAML: %w", err)
+	}
 	prettyJSON, err := json.MarshalIndent(job, "", "  ")
 
 	if err != nil {
@@ -292,6 +299,7 @@ func (s *Sk8lServer) GetJobYAML(ctx context.Context, in *protos.JobRequest) (*pr
 			Err(err).
 			Str("operation", "sk8l#GetJobYAML").
 			Msg("json.MarshalIndent() failed")
+		return nil, fmt.Errorf("sk8l#GetJobYAML: json.MarshalIndent failed: %w", err)
 	}
 
 	y, _ := gyaml.JSONToYAML(prettyJSON)
@@ -304,7 +312,10 @@ func (s *Sk8lServer) GetJobYAML(ctx context.Context, in *protos.JobRequest) (*pr
 }
 
 func (s *Sk8lServer) GetPodYAML(ctx context.Context, in *protos.PodRequest) (*protos.PodYAMLResponse, error) {
-	pod := s.K8sClient.GetPod(ctx, in.PodNamespace, in.PodName)
+	pod, err := s.K8sClient.GetPod(ctx, in.PodNamespace, in.PodName)
+	if err != nil {
+		return nil, fmt.Errorf("sk8l#GetPodYAML: %w", err)
+	}
 	prettyJSON, err := json.MarshalIndent(pod, "", "  ")
 
 	if err != nil {
@@ -312,6 +323,7 @@ func (s *Sk8lServer) GetPodYAML(ctx context.Context, in *protos.PodRequest) (*pr
 			Err(err).
 			Str("operation", "sk8l#GetPodYAML").
 			Msg("json.MarshalIndent() failed")
+		return nil, fmt.Errorf("sk8l#GetPodYAML: json.MarshalIndent failed: %w", err)
 	}
 
 	y, _ := gyaml.JSONToYAML(prettyJSON)
@@ -445,36 +457,59 @@ func (s *Sk8lServer) buildJobResponse(batchJob *batchv1.Job) *protos.JobResponse
 }
 
 func (s *Sk8lServer) collectCronjobs(ctx context.Context) {
-	x := s.K8sClient.WatchCronjobs(ctx)
-
 	go func() {
 		for {
-			event, more := <-x.ResultChan()
-			if more {
-				eventCronjob, ok := event.Object.(*batchv1.CronJob)
-				if !ok {
-					log.Error().
-						Str("operation", "collectCronjobs").
-						Msg("event.Object.(*batchv1.CronJob)")
-				}
-				err := s.DB.Update(func(txn *badger.Txn) error {
-					return handleCronJobEvent(txn, event, eventCronjob)
-				})
-				if err != nil {
-					panic(err)
-				}
-			} else {
+			x, err := s.K8sClient.WatchCronjobs(ctx)
+			if err != nil {
+				log.Error().
+					Err(err).
+					Str("operation", "collectCronjobs").
+					Msg("WatchCronjobs failed, retrying in 5s")
 				select {
 				case <-ctx.Done():
 					log.Info().
 						Str("operation", "collectCronjobs").
 						Msg("context canceled, stopping watcher")
 					return
-				default:
-					x = s.K8sClient.WatchCronjobs(ctx)
-					log.Error().
+				case <-time.After(5 * time.Second):
+					continue
+				}
+			}
+
+			running := true
+			for running {
+				select {
+				case <-ctx.Done():
+					x.Stop()
+					log.Info().
 						Str("operation", "collectCronjobs").
-						Msg("WatchCronjobs: Received all Cronjobs. Opening again")
+						Msg("context canceled, stopping watcher")
+					return
+				case event, more := <-x.ResultChan():
+					if !more {
+						log.Error().
+							Str("operation", "collectCronjobs").
+							Msg("WatchCronjobs: Received all Cronjobs. Opening again")
+						running = false
+						break
+					}
+
+					eventCronjob, ok := event.Object.(*batchv1.CronJob)
+					if !ok {
+						log.Error().
+							Str("operation", "collectCronjobs").
+							Msg("event.Object.(*batchv1.CronJob) type assertion failed")
+						continue
+					}
+					err := s.DB.Update(func(txn *badger.Txn) error {
+						return handleCronJobEvent(txn, event, eventCronjob)
+					})
+					if err != nil {
+						log.Error().
+							Err(err).
+							Str("operation", "collectCronjobs").
+							Msg("handleCronJobEvent failed")
+					}
 				}
 			}
 		}
@@ -482,36 +517,59 @@ func (s *Sk8lServer) collectCronjobs(ctx context.Context) {
 }
 
 func (s *Sk8lServer) collectJobs(ctx context.Context) {
-	x := s.K8sClient.WatchJobs(ctx)
-
 	go func() {
 		for {
-			event, more := <-x.ResultChan()
-			if more {
-				eventJob, ok := event.Object.(*batchv1.Job)
-				if !ok {
-					log.Error().
-						Str("operation", "collectPods").
-						Msg("event.Object.(*batchv1.Job)")
-				}
-				err := s.DB.Update(func(txn *badger.Txn) error {
-					return handleJobEvent(txn, event, eventJob)
-				})
-				if err != nil {
-					panic(err)
-				}
-			} else {
+			x, err := s.K8sClient.WatchJobs(ctx)
+			if err != nil {
+				log.Error().
+					Err(err).
+					Str("operation", "collectJobs").
+					Msg("WatchJobs failed, retrying in 5s")
 				select {
 				case <-ctx.Done():
 					log.Info().
 						Str("operation", "collectJobs").
 						Msg("context canceled, stopping watcher")
 					return
-				default:
-					x = s.K8sClient.WatchJobs(ctx)
-					log.Error().
+				case <-time.After(5 * time.Second):
+					continue
+				}
+			}
+
+			running := true
+			for running {
+				select {
+				case <-ctx.Done():
+					x.Stop()
+					log.Info().
 						Str("operation", "collectJobs").
-						Msg("WatchJobs: Received all Jobs. Opening again")
+						Msg("context canceled, stopping watcher")
+					return
+				case event, more := <-x.ResultChan():
+					if !more {
+						log.Error().
+							Str("operation", "collectJobs").
+							Msg("WatchJobs: Received all Jobs. Opening again")
+						running = false
+						break
+					}
+
+					eventJob, ok := event.Object.(*batchv1.Job)
+					if !ok {
+						log.Error().
+							Str("operation", "collectJobs").
+							Msg("event.Object.(*batchv1.Job) type assertion failed")
+						continue
+					}
+					err := s.DB.Update(func(txn *badger.Txn) error {
+						return handleJobEvent(txn, event, eventJob)
+					})
+					if err != nil {
+						log.Error().
+							Err(err).
+							Str("operation", "collectJobs").
+							Msg("handleJobEvent failed")
+					}
 				}
 			}
 		}
@@ -519,36 +577,59 @@ func (s *Sk8lServer) collectJobs(ctx context.Context) {
 }
 
 func (s *Sk8lServer) collectPods(ctx context.Context) {
-	x := s.K8sClient.WatchPods(ctx)
-
 	go func() {
 		for {
-			event, more := <-x.ResultChan()
-			if more {
-				eventPod, ok := event.Object.(*corev1.Pod)
-				if !ok {
-					log.Error().
-						Str("operation", "collectPods").
-						Msg("event.Object.(*corev1.Pod)")
-				}
-				err := s.DB.Update(func(txn *badger.Txn) error {
-					return handlePodEvent(txn, event, eventPod)
-				})
-				if err != nil {
-					panic(err)
-				}
-			} else {
+			x, err := s.K8sClient.WatchPods(ctx)
+			if err != nil {
+				log.Error().
+					Err(err).
+					Str("operation", "collectPods").
+					Msg("WatchPods failed, retrying in 5s")
 				select {
 				case <-ctx.Done():
 					log.Info().
 						Str("operation", "collectPods").
 						Msg("context canceled, stopping watcher")
 					return
-				default:
-					x = s.K8sClient.WatchPods(ctx)
-					log.Error().
+				case <-time.After(5 * time.Second):
+					continue
+				}
+			}
+
+			running := true
+			for running {
+				select {
+				case <-ctx.Done():
+					x.Stop()
+					log.Info().
 						Str("operation", "collectPods").
-						Msg("WatchJobs: Received all Pods. Opening again")
+						Msg("context canceled, stopping watcher")
+					return
+				case event, more := <-x.ResultChan():
+					if !more {
+						log.Error().
+							Str("operation", "collectPods").
+							Msg("WatchPods: Received all Pods. Opening again")
+						running = false
+						break
+					}
+
+					eventPod, ok := event.Object.(*corev1.Pod)
+					if !ok {
+						log.Error().
+							Str("operation", "collectPods").
+							Msg("event.Object.(*corev1.Pod) type assertion failed")
+						continue
+					}
+					err := s.DB.Update(func(txn *badger.Txn) error {
+						return handlePodEvent(txn, event, eventPod)
+					})
+					if err != nil {
+						log.Error().
+							Err(err).
+							Str("operation", "collectPods").
+							Msg("handlePodEvent failed")
+					}
 				}
 			}
 		}

--- a/sk8l_test.go
+++ b/sk8l_test.go
@@ -183,6 +183,151 @@ func TestGetCronjobYAML(t *testing.T) {
 	}
 }
 
+func TestGetCronjobYAML_NotFound(t *testing.T) {
+	db := setupBadger(t)
+	defer db.Close()
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(bufDialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	clientSet := fake.NewClientset()
+	k8sClient := k8s.NewClientWithInterface(clientSet)
+	st := &store.CronJobDBStore{
+		DB:        db,
+		K8sClient: k8sClient,
+	}
+	sk8lServer.CronJobDBStore = st
+
+	client := protos.NewCronjobClient(conn)
+	_, err = client.GetCronjobYAML(ctx, &protos.CronjobRequest{
+		CronjobName:      "non-existent",
+		CronjobNamespace: "default",
+	})
+	if err == nil {
+		t.Error("expected error for non-existent cronjob, got nil")
+	}
+}
+
+func TestGetJobYAML(t *testing.T) {
+	db := setupBadger(t)
+	defer db.Close()
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(bufDialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	job := testutil.NewJobBuilder().
+		WithName("test-job").
+		WithNamespace("default").
+		Build()
+
+	clientSet := fake.NewClientset(job)
+	k8sClient := k8s.NewClientWithInterface(clientSet)
+	st := &store.CronJobDBStore{
+		DB:        db,
+		K8sClient: k8sClient,
+	}
+	sk8lServer.CronJobDBStore = st
+
+	client := protos.NewCronjobClient(conn)
+
+	// Success case
+	yamlResp, err := client.GetJobYAML(ctx, &protos.JobRequest{
+		JobName:      "test-job",
+		JobNamespace: "default",
+	})
+	if err != nil {
+		t.Fatalf("GetJobYAML failed: %v", err)
+	}
+	if yamlResp.Job == "" {
+		t.Error("expected non-empty Job YAML")
+	}
+
+	// Error case (not found)
+	_, err = client.GetJobYAML(ctx, &protos.JobRequest{
+		JobName:      "non-existent-job",
+		JobNamespace: "default",
+	})
+	if err == nil {
+		t.Error("expected error for non-existent job, got nil")
+	}
+}
+
+func TestGetPodYAML(t *testing.T) {
+	db := setupBadger(t)
+	defer db.Close()
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(bufDialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+	}
+
+	clientSet := fake.NewClientset(pod)
+	k8sClient := k8s.NewClientWithInterface(clientSet)
+	st := &store.CronJobDBStore{
+		DB:        db,
+		K8sClient: k8sClient,
+	}
+	sk8lServer.CronJobDBStore = st
+
+	client := protos.NewCronjobClient(conn)
+
+	// Success case
+	yamlResp, err := client.GetPodYAML(ctx, &protos.PodRequest{
+		PodName:      "test-pod",
+		PodNamespace: "default",
+	})
+	if err != nil {
+		t.Fatalf("GetPodYAML failed: %v", err)
+	}
+	if yamlResp.Pod == "" {
+		t.Error("expected non-empty Pod YAML")
+	}
+
+	// Error case (not found)
+	_, err = client.GetPodYAML(ctx, &protos.PodRequest{
+		PodName:      "non-existent-pod",
+		PodNamespace: "default",
+	})
+	if err == nil {
+		t.Error("expected error for non-existent pod, got nil")
+	}
+}
+
 func TestGetCronjosbDB(t *testing.T) {
 	db := setupBadger(t)
 	defer db.Close()
@@ -391,12 +536,17 @@ func TestGetCronjobsService(t *testing.T) {
 			t.Errorf("expected cronjob name %q, got %q", cronJobs.Items[i].Name, cj.Name)
 		}
 
-		if cj.Jobs[0].WithSidecarContainers != true {
-			t.Error("expected WithSidecarContainers to be false", cj.Jobs[0].WithSidecarContainers)
-		}
-
-		if cj.Jobs[1].WithSidecarContainers != false {
-			t.Error("expected WithSidecarContainers to be true", cj.Jobs[1].WithSidecarContainers)
+		for _, j := range cj.Jobs {
+			switch j.Name {
+			case "process-videos":
+				if !j.WithSidecarContainers {
+					t.Errorf("expected job %s WithSidecarContainers to be true, got false", j.Name)
+				}
+			case "process-reports":
+				if j.WithSidecarContainers {
+					t.Errorf("expected job %s WithSidecarContainers to be false, got true", j.Name)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
- Refactor k8s.Client and ClientInterface to return error on all API calls and watches instead of panicking
- Refactor store.NewCronJobDBStore to return error instead of calling log.Fatal()
- Fix BadgerTTL duration calculation (15s) and main.go timeout duration constants
- Add retry loops with backoff to watcher routines and metrics stream collector
- Add comprehensive unit tests for internal/k8s, internal/store, and internal/dashboard