### PR TITLE
ci: fix check_k8s_mapper_drift.sh false positives in get_upstream_fields

### DIFF
--- a/.changelog/279.txt
+++ b/.changelog/279.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ci: fix false-positive "new field" reports in check_k8s_mapper_drift.sh by stopping go doc output parsing at the struct closing brace, eliminating receiver type names (e.g. EnvVar, JobSpec, PodStatus) from being treated as upstream fields
+```

--- a/ci/check_k8s_mapper_drift.sh
+++ b/ci/check_k8s_mapper_drift.sh
@@ -16,6 +16,7 @@ echo ""
 get_upstream_fields() {
     local type_path=$1
     go doc "${type_path}" 2>/dev/null \
+        | sed '/^}/,$d' \
         | grep -E '^\s+[A-Z][A-Za-z0-9]+\s' \
         | awk '{print $1}' \
         | sort


### PR DESCRIPTION
`go doc` appends method signatures below the struct closing brace, and the grep/awk pipeline was capturing receiver type names from those lines (e.g. `EnvVar`, `JobSpec`, `PodStatus`) as if they were real struct fields. 

Pipe through `sed '/^}/,$d'` to stop parsing at the struct's closing brace, before the description and method list begin.